### PR TITLE
feat(T009): configure Playwright for E2E testing

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,11 @@
     "lint": "biome lint .",
     "test": "vitest run",
     "test:watch": "vitest",
-    "test:coverage": "vitest run --coverage"
+    "test:coverage": "vitest run --coverage",
+    "test:e2e": "playwright test",
+    "test:e2e:ui": "playwright test --ui",
+    "test:e2e:headed": "playwright test --headed",
+    "test:e2e:debug": "playwright test --debug"
   },
   "dependencies": {
     "class-variance-authority": "^0.7.1",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,52 @@
+import { defineConfig, devices } from '@playwright/test';
+
+/**
+ * Playwright E2E test configuration
+ * @see https://playwright.dev/docs/test-configuration
+ */
+export default defineConfig({
+  testDir: './tests/e2e',
+  /* Run tests in files in parallel */
+  fullyParallel: true,
+  /* Fail the build on CI if you accidentally left test.only in the source code. */
+  forbidOnly: !!process.env.CI,
+  /* Retry on CI only */
+  retries: process.env.CI ? 2 : 0,
+  /* Opt out of parallel tests on CI. */
+  workers: process.env.CI ? 1 : undefined,
+  /* Reporter to use. See https://playwright.dev/docs/test-reporters */
+  reporter: process.env.CI ? 'html' : 'list',
+  /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
+  use: {
+    /* Base URL to use in actions like `await page.goto('/')`. */
+    baseURL: 'http://localhost:5173',
+    /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
+    trace: 'on-first-retry',
+    /* Take screenshot on failure */
+    screenshot: 'only-on-failure',
+  },
+
+  /* Configure projects for major browsers */
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+    {
+      name: 'firefox',
+      use: { ...devices['Desktop Firefox'] },
+    },
+    {
+      name: 'webkit',
+      use: { ...devices['Desktop Safari'] },
+    },
+  ],
+
+  /* Run your local dev server before starting the tests */
+  webServer: {
+    command: 'pnpm dev',
+    url: 'http://localhost:5173',
+    reuseExistingServer: !process.env.CI,
+    timeout: 120000,
+  },
+});

--- a/specs/001-interactive-history-map/tasks.md
+++ b/specs/001-interactive-history-map/tasks.md
@@ -33,7 +33,7 @@
 - [x] T006 [P] MapLibre GL JSとreact-map-glをインストール: `pnpm add maplibre-gl react-map-gl pmtiles`
 - [x] T007 [P] テスト依存関係をインストール: `pnpm add -D vitest @testing-library/react @testing-library/jest-dom jsdom @playwright/test`
 - [x] T008 `vitest.config.ts` でVitestを設定
-- [ ] T009 [P] `playwright.config.ts` でPlaywrightを設定
+- [x] T009 [P] `playwright.config.ts` でPlaywrightを設定
 - [ ] T010 plan.mdに従って `src/` に基本プロジェクト構造を作成
 
 ---

--- a/tests/e2e/app.spec.ts
+++ b/tests/e2e/app.spec.ts
@@ -1,0 +1,14 @@
+import { expect, test } from '@playwright/test';
+
+test.describe('App', () => {
+  test('should load the application', async ({ page }) => {
+    await page.goto('/');
+    await expect(page).toHaveTitle(/World History Atlas/i);
+  });
+
+  test('should display the main content', async ({ page }) => {
+    await page.goto('/');
+    // Verify the page has loaded by checking for any visible content
+    await expect(page.locator('body')).toBeVisible();
+  });
+});


### PR DESCRIPTION
## 概要

Playwright を E2E テスト用に設定しました。

## 変更内容

- `playwright.config.ts` を追加（Chromium、Firefox、WebKit をサポート）
- テストディレクトリを `tests/e2e/` に設定し、適切な webServer 設定を構成
- E2E テストスクリプトを `package.json` に追加（test:e2e, test:e2e:ui, test:e2e:headed, test:e2e:debug）
- 検証用のサンプル E2E テスト（`tests/e2e/app.spec.ts`）を作成
- `tasks.md` で T009 を完了としてマーク

Closes #9

🤖 Generated with [Claude Code](https://claude.com/claude-code)