### PR TITLE
style: use dot notation instead of bracket notation

### DIFF
--- a/src/utils/year-index.ts
+++ b/src/utils/year-index.ts
@@ -14,11 +14,10 @@ function validateYearEntry(entry: unknown): entry is YearEntry {
     return false;
   }
 
-  // biome-ignore lint/complexity/useLiteralKeys: Using bracket notation for type guard validation
   const e = entry as Record<string, unknown>;
-  const year = e['year'];
-  const filename = e['filename'];
-  const countries = e['countries'];
+  const year = e.year;
+  const filename = e.filename;
+  const countries = e.countries;
 
   if (typeof year !== 'number' || !Number.isInteger(year)) {
     return false;
@@ -47,9 +46,8 @@ function validateYearIndex(data: unknown): data is YearIndex {
     return false;
   }
 
-  // biome-ignore lint/complexity/useLiteralKeys: Using bracket notation for type guard validation
   const d = data as Record<string, unknown>;
-  const years = d['years'];
+  const years = d.years;
 
   if (!Array.isArray(years)) {
     return false;


### PR DESCRIPTION
## 概要

Biome lintの警告を解消するため、オブジェクトプロパティへのアクセス方法をブラケット記法からドット記法に変更しました。

## 変更内容

- `src/utils/year-index.ts`: `e['year']` → `e.year` などのドット記法に変更
- 不要な `biome-ignore` コメントを削除

🤖 Generated with [Claude Code](https://claude.com/claude-code)