### PR TITLE
docs: add LICENSE-data.txt for map data attribution

### DIFF
--- a/public/LICENSE-data.txt
+++ b/public/LICENSE-data.txt
@@ -1,0 +1,35 @@
+Map Data License and Attribution
+=================================
+
+This application uses historical map data from the following source:
+
+Source Project
+--------------
+Name: historical-basemaps
+Author: André Ourednik
+Repository: https://github.com/aourednik/historical-basemaps
+
+License
+-------
+The map data is licensed under the GNU General Public License v3.0 (GPL-3.0).
+
+Full license text: https://www.gnu.org/licenses/gpl-3.0.en.html
+
+Summary of GPL-3.0
+------------------
+- You are free to use, modify, and distribute this data
+- If you distribute modified versions, you must:
+  - Make the source available under GPL-3.0
+  - Include this license notice
+  - State your changes
+- No warranty is provided
+
+Attribution
+-----------
+When using this data, please credit:
+"Map data based on historical-basemaps by André Ourednik (GPL-3.0)"
+
+Contact
+-------
+For questions about the original data, please visit:
+https://github.com/aourednik/historical-basemaps

--- a/src/components/legal/license-disclaimer.tsx
+++ b/src/components/legal/license-disclaimer.tsx
@@ -155,6 +155,16 @@ export function LicenseDisclaimer({ isOpen, onClose }: LicenseDisclaimerProps) {
                 </span>{' '}
                 の下で提供されています。
               </p>
+              <p className="mt-2 text-sm text-gray-200">
+                <a
+                  href="/LICENSE-data.txt"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="font-medium text-blue-400 hover:underline"
+                >
+                  ライセンス全文を見る
+                </a>
+              </p>
             </div>
           </section>
 


### PR DESCRIPTION
## 概要

地図データのライセンス情報を明示的に配布するためのファイルを追加しました。

- `public/LICENSE-data.txt` を作成
  - historical-basemaps プロジェクトへの帰属表示
  - GPL-3.0 ライセンスの説明
  - 利用時の Attribution 記載例
- LicenseDisclaimer コンポーネントに「ライセンス全文を見る」リンクを追加

## 背景

GPL-3.0ライセンスの地図データを使用しているため、ライセンス情報を発見可能な形で提供する必要がありました。これにより、デプロイ後 `/LICENSE-data.txt` でライセンス情報にアクセス可能になります。

## テスト

- [x] `pnpm check` パス
- [x] `pnpm test` パス (91 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)