### PR TITLE
fix: use dvh units to fix mobile viewport height issue

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -54,7 +54,7 @@ function AppContent() {
   }, []);
 
   return (
-    <main className="relative h-screen w-screen overflow-hidden">
+    <main className="relative h-dvh w-screen overflow-hidden">
       <MapView />
       <TerritoryInfoPanel />
       {!isLoading && years.length > 0 && (

--- a/src/index.css
+++ b/src/index.css
@@ -33,7 +33,7 @@
 body {
   margin: 0;
   min-width: 320px;
-  min-height: 100vh;
+  min-height: 100dvh;
   overflow: hidden;
 }
 


### PR DESCRIPTION
## Summary

- モバイルブラウザ（iOS Chrome/Safari）で年代選択スライダーがアドレスバーに隠れる問題を修正
- `100vh` を `100dvh` (dynamic viewport height) に置き換え
- `dvh` はツールバーの表示状態に応じて動的に調整されるCSS単位

## 変更内容

- `src/App.tsx`: `h-screen` → `h-dvh`
- `src/index.css`: `min-height: 100vh` → `min-height: 100dvh`

## Test plan

- [x] iPhoneの実機でChromeを使って年代選択スライダーが表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)