### PR TITLE
chore: add dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,44 @@
+version: 2
+updates:
+  # npm dependencies
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+      time: "09:00"
+      timezone: Asia/Tokyo
+    open-pull-requests-limit: 10
+    groups:
+      production:
+        dependency-type: production
+        update-types:
+          - minor
+          - patch
+      dev-dependencies:
+        dependency-type: development
+        update-types:
+          - minor
+          - patch
+    labels:
+      - dependencies
+
+  # GitHub Actions
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+      time: "09:00"
+      timezone: Asia/Tokyo
+    open-pull-requests-limit: 5
+    groups:
+      actions:
+        patterns:
+          - "*"
+        update-types:
+          - minor
+          - patch
+    labels:
+      - dependencies
+      - github-actions


### PR DESCRIPTION
## 概要

Dependabot を設定し、依存関係の自動更新を有効化します。

## 変更内容

- `.github/dependabot.yml` を追加
- 毎週月曜日 9:00 (JST) に更新チェックを実行
- npm 依存関係と GitHub Actions の両方を対象
- minor/patch 更新はグループ化して PR 数を削減
  - production dependencies
  - dev dependencies
  - GitHub Actions

🤖 Generated with [Claude Code](https://claude.com/claude-code)