### PR TITLE
refactor(frontend): add cn helper with clsx + tailwind-merge

### DIFF
--- a/apps/frontend/package.json
+++ b/apps/frontend/package.json
@@ -13,11 +13,13 @@
     "build-storybook": "storybook build"
   },
   "dependencies": {
+    "clsx": "^2.1.1",
     "maplibre-gl": "^5.18.0",
     "pmtiles": "^4.4.0",
     "react": "^19.2.4",
     "react-dom": "^19.2.4",
-    "react-map-gl": "^8.1.0"
+    "react-map-gl": "^8.1.0",
+    "tailwind-merge": "^3.5.0"
   },
   "devDependencies": {
     "@storybook/addon-a11y": "^10.2.8",

--- a/apps/frontend/src/components/map/projection-toggle.tsx
+++ b/apps/frontend/src/components/map/projection-toggle.tsx
@@ -1,4 +1,5 @@
 import { type ComponentProps, forwardRef } from 'react';
+import { cn } from '@/lib/utils';
 
 /**
  * Projection type for the map
@@ -25,7 +26,7 @@ interface ProjectionToggleProps
  * ```
  */
 export const ProjectionToggle = forwardRef<HTMLButtonElement, ProjectionToggleProps>(
-  ({ projection, onToggle, className = '', ...props }, ref) => {
+  ({ projection, onToggle, className, ...props }, ref) => {
     const handleClick = () => {
       onToggle(projection === 'mercator' ? 'globe' : 'mercator');
     };
@@ -37,7 +38,10 @@ export const ProjectionToggle = forwardRef<HTMLButtonElement, ProjectionTogglePr
         ref={ref}
         type="button"
         onClick={handleClick}
-        className={`rounded-lg bg-gray-700/95 p-3 text-gray-300 shadow-lg backdrop-blur-sm transition-colors hover:bg-gray-600 hover:text-white ${className}`}
+        className={cn(
+          'rounded-lg bg-gray-700/95 p-3 text-gray-300 shadow-lg backdrop-blur-sm transition-colors hover:bg-gray-600 hover:text-white',
+          className,
+        )}
         aria-label={isGlobe ? '平面地図に切り替え' : '地球儀表示に切り替え'}
         aria-pressed={isGlobe}
         {...props}

--- a/apps/frontend/src/components/territory-info/ai-notice.tsx
+++ b/apps/frontend/src/components/territory-info/ai-notice.tsx
@@ -1,3 +1,5 @@
+import { cn } from '@/lib/utils';
+
 /**
  * AI Notice props
  */
@@ -18,11 +20,14 @@ interface AiNoticeProps {
  * <AiNotice />
  * ```
  */
-export function AiNotice({ className = '' }: AiNoticeProps) {
+export function AiNotice({ className }: AiNoticeProps) {
   return (
     <div
       data-testid="ai-notice"
-      className={`flex items-center gap-1.5 rounded-md bg-amber-900/30 px-3 py-2 text-xs text-amber-300 ${className}`}
+      className={cn(
+        'flex items-center gap-1.5 rounded-md bg-amber-900/30 px-3 py-2 text-xs text-amber-300',
+        className,
+      )}
       role="note"
       aria-label="AI生成コンテンツの注意"
     >

--- a/apps/frontend/src/components/territory-info/territory-info-panel.tsx
+++ b/apps/frontend/src/components/territory-info/territory-info-panel.tsx
@@ -1,6 +1,7 @@
 import type { ReactNode } from 'react';
 import { useCallback, useMemo } from 'react';
 import { useEscapeKey } from '@/hooks/use-escape-key';
+import { cn } from '@/lib/utils';
 import { useAppState } from '../../contexts/app-state-context';
 import { CloseButton } from '../ui/close-button';
 import { AiNotice } from './ai-notice';
@@ -25,7 +26,10 @@ function PanelWrapper({
       role="dialog"
       aria-labelledby="territory-info-title"
       aria-busy={busy || undefined}
-      className={`absolute left-4 top-4 z-30 w-96 max-w-[calc(100vw-2rem)] rounded-lg bg-gray-700/95 p-4 shadow-xl backdrop-blur-sm${scrollable ? ' max-h-[calc(100vh-2rem)] overflow-y-auto' : ''}`}
+      className={cn(
+        'absolute left-4 top-4 z-30 w-96 max-w-[calc(100vw-2rem)] rounded-lg bg-gray-700/95 p-4 shadow-xl backdrop-blur-sm',
+        scrollable && 'max-h-[calc(100vh-2rem)] overflow-y-auto',
+      )}
     >
       {children}
     </aside>

--- a/apps/frontend/src/components/territory-info/year-link.tsx
+++ b/apps/frontend/src/components/territory-info/year-link.tsx
@@ -1,4 +1,5 @@
 import { useCallback } from 'react';
+import { cn } from '@/lib/utils';
 import { useAppState } from '../../contexts/app-state-context';
 
 /**
@@ -23,7 +24,7 @@ interface YearLinkProps {
  * // Renders: "1700年"
  * ```
  */
-export function YearLink({ year, className = '' }: YearLinkProps) {
+export function YearLink({ year, className }: YearLinkProps) {
   const { actions } = useAppState();
 
   const handleClick = useCallback(() => {
@@ -50,7 +51,10 @@ export function YearLink({ year, className = '' }: YearLinkProps) {
       onClick={handleClick}
       onKeyDown={handleKeyDown}
       data-testid="year-link"
-      className={`inline-flex items-center rounded-full bg-gray-600 px-3 py-1 text-sm font-medium text-gray-200 transition-colors hover:bg-blue-600 hover:text-white ${className}`}
+      className={cn(
+        'inline-flex items-center rounded-full bg-gray-600 px-3 py-1 text-sm font-medium text-gray-200 transition-colors hover:bg-blue-600 hover:text-white',
+        className,
+      )}
       aria-label={`${year}年に移動`}
     >
       {year}年

--- a/apps/frontend/src/components/ui/close-button.tsx
+++ b/apps/frontend/src/components/ui/close-button.tsx
@@ -1,4 +1,5 @@
 import { type ComponentProps, forwardRef } from 'react';
+import { cn } from '@/lib/utils';
 
 interface CloseButtonProps extends Omit<ComponentProps<'button'>, 'children'> {
   /** Size of the button */
@@ -9,15 +10,18 @@ interface CloseButtonProps extends Omit<ComponentProps<'button'>, 'children'> {
  * Reusable close button component with X icon
  */
 export const CloseButton = forwardRef<HTMLButtonElement, CloseButtonProps>(
-  ({ size = 'md', className = '', ...props }, ref) => {
-    const sizeClasses = size === 'sm' ? 'p-1' : 'p-1.5';
+  ({ size = 'md', className, ...props }, ref) => {
     const iconSize = size === 'sm' ? 'h-4 w-4' : 'h-5 w-5';
 
     return (
       <button
         ref={ref}
         type="button"
-        className={`rounded-lg text-gray-300 transition-colors hover:bg-gray-600 hover:text-white ${sizeClasses} ${className}`}
+        className={cn(
+          'rounded-lg text-gray-300 transition-colors hover:bg-gray-600 hover:text-white',
+          size === 'sm' ? 'p-1' : 'p-1.5',
+          className,
+        )}
         {...props}
       >
         <svg

--- a/apps/frontend/src/components/year-selector/year-selector.tsx
+++ b/apps/frontend/src/components/year-selector/year-selector.tsx
@@ -1,4 +1,5 @@
 import { type KeyboardEvent, useCallback, useEffect, useMemo, useRef } from 'react';
+import { cn } from '@/lib/utils';
 import { useAppState } from '../../contexts/app-state-context';
 import type { YearEntry } from '../../types/year';
 
@@ -155,11 +156,12 @@ export function YearSelector({ years, onYearSelect }: YearSelectorProps) {
         onClick={() => navigateYear('prev')}
         disabled={!canGoPrev}
         aria-label="前の年代を選択"
-        className={`flex shrink-0 items-center border-r border-gray-600 px-3 py-2 transition-colors ${
+        className={cn(
+          'flex shrink-0 items-center border-r border-gray-600 px-3 py-2 transition-colors',
           canGoPrev
             ? 'text-gray-300 hover:bg-gray-600 hover:text-white'
-            : 'cursor-not-allowed text-gray-500'
-        }`}
+            : 'cursor-not-allowed text-gray-500',
+        )}
       >
         <svg
           className="h-4 w-4"
@@ -188,11 +190,12 @@ export function YearSelector({ years, onYearSelect }: YearSelectorProps) {
               aria-current={isSelected ? 'true' : undefined}
               onClick={() => handleYearClick(yearEntry.year)}
               onKeyDown={(e) => handleKeyDown(e, index)}
-              className={`flex shrink-0 items-center justify-center border-r border-gray-600 py-3 font-medium transition-colors last:border-r-0 ${
+              className={cn(
+                'flex shrink-0 items-center justify-center border-r border-gray-600 py-3 font-medium transition-colors last:border-r-0',
                 isSelected
                   ? 'min-w-[5rem] bg-blue-600 px-5 text-xl text-white'
-                  : 'min-w-[4rem] px-3 text-base text-gray-300 hover:bg-gray-600 hover:text-white'
-              }`}
+                  : 'min-w-[4rem] px-3 text-base text-gray-300 hover:bg-gray-600 hover:text-white',
+              )}
             >
               {formatYear(yearEntry.year)}
             </button>
@@ -206,11 +209,12 @@ export function YearSelector({ years, onYearSelect }: YearSelectorProps) {
         onClick={() => navigateYear('next')}
         disabled={!canGoNext}
         aria-label="次の年代を選択"
-        className={`flex shrink-0 items-center border-l border-gray-600 px-3 py-2 transition-colors ${
+        className={cn(
+          'flex shrink-0 items-center border-l border-gray-600 px-3 py-2 transition-colors',
           canGoNext
             ? 'text-gray-300 hover:bg-gray-600 hover:text-white'
-            : 'cursor-not-allowed text-gray-500'
-        }`}
+            : 'cursor-not-allowed text-gray-500',
+        )}
       >
         <svg
           className="h-4 w-4"

--- a/apps/frontend/src/lib/utils.ts
+++ b/apps/frontend/src/lib/utils.ts
@@ -1,0 +1,6 @@
+import { type ClassValue, clsx } from 'clsx';
+import { twMerge } from 'tailwind-merge';
+
+export function cn(...inputs: ClassValue[]) {
+  return twMerge(clsx(...inputs));
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,6 +17,9 @@ importers:
 
   apps/frontend:
     dependencies:
+      clsx:
+        specifier: ^2.1.1
+        version: 2.1.1
       maplibre-gl:
         specifier: ^5.18.0
         version: 5.18.0
@@ -32,6 +35,9 @@ importers:
       react-map-gl:
         specifier: ^8.1.0
         version: 8.1.0(maplibre-gl@5.18.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      tailwind-merge:
+        specifier: ^3.5.0
+        version: 3.5.0
     devDependencies:
       '@storybook/addon-a11y':
         specifier: ^10.2.8
@@ -1678,6 +1684,10 @@ packages:
     resolution: {integrity: sha512-OAlb+T7V4Op9OwdkjmguYRqncdlx5JiofwOAUkmTF+jNdHwzTaTs4sRAGpzLF3oOz5xAyDGrPgeIDFQmDOTiJw==}
     engines: {node: '>= 16'}
 
+  clsx@2.1.1:
+    resolution: {integrity: sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==}
+    engines: {node: '>=6'}
+
   commander@2.20.3:
     resolution: {integrity: sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==}
 
@@ -2416,6 +2426,9 @@ packages:
 
   symbol-tree@3.2.4:
     resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
+
+  tailwind-merge@3.5.0:
+    resolution: {integrity: sha512-I8K9wewnVDkL1NTGoqWmVEIlUcB9gFriAEkXkfCjX5ib8ezGxtR3xD7iZIxrfArjEsH7F1CHD4RFUtxefdqV/A==}
 
   tailwindcss@4.1.18:
     resolution: {integrity: sha512-4+Z+0yiYyEtUVCScyfHCxOYP06L5Ne+JiHhY2IjR2KWMIWhJOYZKLSGZaP5HkZ8+bY0cxfzwDE5uOmzFXyIwxw==}
@@ -4876,6 +4889,8 @@ snapshots:
 
   check-error@2.1.1: {}
 
+  clsx@2.1.1: {}
+
   commander@2.20.3: {}
 
   concaveman@1.2.1:
@@ -5630,6 +5645,8 @@ snapshots:
       tinyqueue: 2.0.3
 
   symbol-tree@3.2.4: {}
+
+  tailwind-merge@3.5.0: {}
 
   tailwindcss@4.1.18: {}
 


### PR DESCRIPTION
## Summary
- Add `clsx` + `tailwind-merge` dependencies and create `cn()` helper utility at `src/lib/utils.ts`
- Replace template literal class name concatenation with `cn()` across all 6 components that use dynamic class names
- Remove unnecessary `className = ''` default parameter patterns, as `cn()` handles `undefined` gracefully

## Test plan
- [x] All 122 existing tests pass (`pnpm test`)
- [x] Production build succeeds (`pnpm build`)
- [ ] Verify components render correctly in browser with no visual regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)