### PR TITLE
refactor(frontend): remove unused isLoading and error fields from AppState

### DIFF
--- a/apps/frontend/src/components/year-selector/year-selector.stories.tsx
+++ b/apps/frontend/src/components/year-selector/year-selector.stories.tsx
@@ -33,9 +33,7 @@ const meta = {
           selectedYear: 1650,
           selectedTerritory: null,
           mapView: { longitude: 0, latitude: 30, zoom: 2 },
-          isLoading: false,
           isInfoPanelOpen: false,
-          error: null,
         }}
       >
         <div className="bg-gray-700 p-4">
@@ -75,9 +73,7 @@ export const ManyYears: Story = {
           selectedYear: -500,
           selectedTerritory: null,
           mapView: { longitude: 0, latitude: 30, zoom: 2 },
-          isLoading: false,
           isInfoPanelOpen: false,
-          error: null,
         }}
       >
         <div className="bg-gray-700 p-4">

--- a/apps/frontend/src/components/year-selector/year-selector.test.tsx
+++ b/apps/frontend/src/components/year-selector/year-selector.test.tsx
@@ -33,8 +33,6 @@ describe('YearSelector', () => {
           selectedTerritory: null,
           isInfoPanelOpen: false,
           mapView: { longitude: 0, latitude: 30, zoom: 2 },
-          isLoading: false,
-          error: null,
         }}
       >
         {ui}

--- a/apps/frontend/src/contexts/app-state-context.tsx
+++ b/apps/frontend/src/contexts/app-state-context.tsx
@@ -22,9 +22,7 @@ type AppStateAction =
   | { type: 'SET_SELECTED_YEAR'; year: number }
   | { type: 'SELECT_TERRITORY'; territory: string }
   | { type: 'CLEAR_SELECTION' }
-  | { type: 'SET_MAP_VIEW'; view: MapViewState }
-  | { type: 'SET_LOADING'; loading: boolean }
-  | { type: 'SET_ERROR'; error: string | null };
+  | { type: 'SET_MAP_VIEW'; view: MapViewState };
 
 function appStateReducer(state: AppState, action: AppStateAction): AppState {
   switch (action.type) {
@@ -36,10 +34,6 @@ function appStateReducer(state: AppState, action: AppStateAction): AppState {
       return { ...state, selectedTerritory: null, isInfoPanelOpen: false };
     case 'SET_MAP_VIEW':
       return { ...state, mapView: action.view };
-    case 'SET_LOADING':
-      return { ...state, isLoading: action.loading };
-    case 'SET_ERROR':
-      return { ...state, error: action.error };
   }
 }
 
@@ -55,8 +49,6 @@ export function AppStateProvider({
       selectTerritory: (territory: string) => dispatch({ type: 'SELECT_TERRITORY', territory }),
       clearSelection: () => dispatch({ type: 'CLEAR_SELECTION' }),
       setMapView: (view: MapViewState) => dispatch({ type: 'SET_MAP_VIEW', view }),
-      setLoading: (loading: boolean) => dispatch({ type: 'SET_LOADING', loading }),
-      setError: (error: string | null) => dispatch({ type: 'SET_ERROR', error }),
     }),
     [],
   );

--- a/apps/frontend/src/types/app-state.ts
+++ b/apps/frontend/src/types/app-state.ts
@@ -11,8 +11,6 @@ export interface AppState {
   selectedTerritory: string | null;
   isInfoPanelOpen: boolean;
   mapView: MapViewState;
-  isLoading: boolean;
-  error: string | null;
 }
 
 export const initialAppState: AppState = {
@@ -24,8 +22,6 @@ export const initialAppState: AppState = {
     latitude: MAP_CONFIG.initialLatitude,
     zoom: MAP_CONFIG.initialZoom,
   },
-  isLoading: false,
-  error: null,
 };
 
 export interface AppStateActions {
@@ -33,6 +29,4 @@ export interface AppStateActions {
   selectTerritory: (territory: string) => void;
   clearSelection: () => void;
   setMapView: (view: MapViewState) => void;
-  setLoading: (loading: boolean) => void;
-  setError: (error: string | null) => void;
 }


### PR DESCRIPTION
## 概要

AppState から未使用の `isLoading` と `error` フィールドを削除しました。

### 背景

- AppState にグローバルな `isLoading`/`error` が定義されていましたが、実際にはどこからも使用されていませんでした
- 各非同期処理（年インデックス取得、地図データ取得、領土説明取得）はそれぞれのフック内でローカルに `isLoading`/`error` を管理しており、グローバル状態は不要でした

### 変更内容

- `AppState` 型から `isLoading`, `error` フィールドを削除しました
- `AppStateActions` から `setLoading`, `setError` を削除しました
- `appStateReducer` から `SET_LOADING`, `SET_ERROR` case を削除しました
- Storybook・テストファイルで `AppState` を直接構築している箇所から該当フィールドを削除しました

## 動作確認

- [ ] `pnpm verify` が通る
- [ ] `pnpm test` が全件 pass する
- [ ] 地図の表示・年選択・領土選択が正常に動作する

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)