### PR TITLE
refactor(frontend): remove unused year-index utility functions and add tests

### DIFF
--- a/apps/frontend/src/utils/year-index.test.ts
+++ b/apps/frontend/src/utils/year-index.test.ts
@@ -1,0 +1,106 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { YearIndex } from '../types/year';
+import { clearYearIndexCache, loadYearIndex } from './year-index';
+
+const SAMPLE_INDEX: YearIndex = {
+  years: [
+    { year: -500, filename: 'world_-500.pmtiles', countries: ['Greece', 'Persia'] },
+    { year: 200, filename: 'world_200.pmtiles', countries: ['Rome'] },
+    { year: 1600, filename: 'world_1600.pmtiles', countries: ['Spain', 'England'] },
+  ],
+};
+
+describe('loadYearIndex', () => {
+  beforeEach(() => {
+    clearYearIndexCache();
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(() =>
+        Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve(structuredClone(SAMPLE_INDEX)),
+        }),
+      ),
+    );
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('fetches and returns valid year index', async () => {
+    const result = await loadYearIndex();
+    expect(result).toEqual(SAMPLE_INDEX);
+    expect(fetch).toHaveBeenCalledWith('/pmtiles/index.json');
+  });
+
+  it('returns cached result on subsequent calls', async () => {
+    await loadYearIndex();
+    await loadYearIndex();
+    expect(fetch).toHaveBeenCalledTimes(1);
+  });
+
+  it('throws on fetch failure', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(() => Promise.resolve({ ok: false, status: 404, statusText: 'Not Found' })),
+    );
+    await expect(loadYearIndex()).rejects.toThrow('Failed to load year index: 404 Not Found');
+  });
+
+  it('throws on invalid format - missing years field', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(() => Promise.resolve({ ok: true, json: () => Promise.resolve({ data: [] }) })),
+    );
+    await expect(loadYearIndex()).rejects.toThrow('Invalid year index format');
+  });
+
+  it('throws on invalid format - non-integer year', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(() =>
+        Promise.resolve({
+          ok: true,
+          json: () =>
+            Promise.resolve({
+              years: [{ year: 1.5, filename: 'world_1.pmtiles', countries: [] }],
+            }),
+        }),
+      ),
+    );
+    await expect(loadYearIndex()).rejects.toThrow('Invalid year index format');
+  });
+
+  it('throws on invalid format - invalid filename pattern', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(() =>
+        Promise.resolve({
+          ok: true,
+          json: () =>
+            Promise.resolve({
+              years: [{ year: 200, filename: 'bad_name.pmtiles', countries: [] }],
+            }),
+        }),
+      ),
+    );
+    await expect(loadYearIndex()).rejects.toThrow('Invalid year index format');
+  });
+
+  it('throws on invalid format - non-string country', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(() =>
+        Promise.resolve({
+          ok: true,
+          json: () =>
+            Promise.resolve({
+              years: [{ year: 200, filename: 'world_200.pmtiles', countries: [123] }],
+            }),
+        }),
+      ),
+    );
+    await expect(loadYearIndex()).rejects.toThrow('Invalid year index format');
+  });
+});

--- a/apps/frontend/src/utils/year-index.ts
+++ b/apps/frontend/src/utils/year-index.ts
@@ -73,38 +73,3 @@ export async function loadYearIndex(): Promise<YearIndex> {
 export function clearYearIndexCache(): void {
   cachedYearIndex = null;
 }
-
-export function getYearFilePath(yearIndex: YearIndex, year: number): string | null {
-  const entry = yearIndex.years.find((yearEntry) => yearEntry.year === year);
-  if (!entry) {
-    return null;
-  }
-  return `/pmtiles/${entry.filename}`;
-}
-
-export function findNearestYear(yearIndex: YearIndex, targetYear: number): number | null {
-  if (yearIndex.years.length === 0) {
-    return null;
-  }
-
-  const firstEntry = yearIndex.years[0];
-  if (!firstEntry) {
-    return null;
-  }
-  let nearest = firstEntry.year;
-  let minDiff = Math.abs(targetYear - nearest);
-
-  for (const entry of yearIndex.years) {
-    const diff = Math.abs(targetYear - entry.year);
-    if (diff < minDiff) {
-      minDiff = diff;
-      nearest = entry.year;
-    }
-  }
-
-  return nearest;
-}
-
-export function getSortedYears(yearIndex: YearIndex): number[] {
-  return yearIndex.years.map((yearEntry) => yearEntry.year).sort((a, b) => a - b);
-}


### PR DESCRIPTION
## 概要

`year-index.ts` から未使用のユーティリティ関数を削除し、使用されている `loadYearIndex` のテストを追加しました。

### 背景

- `getYearFilePath`、`findNearestYear`、`getSortedYears` の3関数がコードベースのどこからも参照されていませんでした
- `year-index.ts` は他の utils ファイルと異なりテストが存在しませんでした

### 変更内容

- 未使用の3関数（`getYearFilePath`、`findNearestYear`、`getSortedYears`）を削除しました
- `loadYearIndex` のテスト（7ケース）を追加しました: fetch 成功・キャッシュ挙動・fetch 失敗・バリデーションエラー4パターン

## 動作確認

- [ ] 全既存テスト（198件）がパスする
- [ ] 新規テスト（7件）がパスする
- [ ] `pnpm check` がパスする

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)