### PR TITLE
refactor(frontend): remove dead code and unexport internal functions

### DIFF
--- a/apps/frontend/src/utils/color-scheme.test.ts
+++ b/apps/frontend/src/utils/color-scheme.test.ts
@@ -1,12 +1,7 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
-import {
-  clearColorSchemeCache,
-  createMatchColorExpression,
-  getColorForSubjecto,
-  loadColorScheme,
-} from './color-scheme';
+import { clearColorSchemeCache, createMatchColorExpression, loadColorScheme } from './color-scheme';
 
 const colorSchemeJson = JSON.parse(
   fs.readFileSync(path.resolve(__dirname, '../../public/data/color-scheme.json'), 'utf8'),
@@ -35,31 +30,6 @@ describe('color-scheme', () => {
   afterEach(() => {
     clearColorSchemeCache();
     mockFetch.mockReset();
-  });
-
-  describe('getColorForSubjecto', () => {
-    it('should return predefined color for major powers', () => {
-      expect(getColorForSubjecto('France')).toBe('#377eb8');
-      expect(getColorForSubjecto('England')).toBe('#e41a1c');
-      expect(getColorForSubjecto('Spanish Habsburg')).toBe('#e6c74c');
-      expect(getColorForSubjecto('Ottoman Empire')).toBe('#b22222');
-    });
-
-    it('should return hash-based color for other territories', () => {
-      const color = getColorForSubjecto('Cree');
-      expect(color).toMatch(/^hsl\(\d+,\s*\d+%,\s*\d+%\)$/);
-    });
-
-    it('should return consistent color for same SUBJECTO', () => {
-      const color1 = getColorForSubjecto('Cree');
-      const color2 = getColorForSubjecto('Cree');
-      expect(color1).toBe(color2);
-    });
-
-    it('should return default color for unknown SUBJECTO', () => {
-      const color = getColorForSubjecto('NonExistentTerritory12345');
-      expect(color).toBe('#cccccc');
-    });
   });
 
   describe('createMatchColorExpression', () => {

--- a/apps/frontend/src/utils/color-scheme.ts
+++ b/apps/frontend/src/utils/color-scheme.ts
@@ -22,13 +22,6 @@ export function clearColorSchemeCache(): void {
   cachedColorScheme = null;
 }
 
-export function getColorForSubjecto(subjecto: string): string {
-  if (!cachedColorScheme) {
-    return DEFAULT_COLOR;
-  }
-  return cachedColorScheme[subjecto] ?? DEFAULT_COLOR;
-}
-
 export function createMatchColorExpression(): ExpressionSpecification {
   if (!cachedColorScheme) {
     return ['literal', DEFAULT_COLOR] as unknown as ExpressionSpecification;

--- a/apps/frontend/src/utils/tiles-config.ts
+++ b/apps/frontend/src/utils/tiles-config.ts
@@ -10,13 +10,13 @@ const DEV_MANIFEST: TilesManifest = {
 
 let cachedManifest: TilesManifest | null = null;
 
-export function getTilesBaseUrl(): string {
+function getTilesBaseUrl(): string {
   const url = import.meta.env.VITE_TILES_BASE_URL || '';
   // Remove trailing slash to avoid double slashes in URLs
   return url.replace(/\/+$/, '');
 }
 
-export function isProductionTiles(): boolean {
+function isProductionTiles(): boolean {
   return !!import.meta.env.VITE_TILES_BASE_URL;
 }
 
@@ -41,7 +41,7 @@ export async function loadTilesManifest(): Promise<TilesManifest> {
   return cachedManifest;
 }
 
-export function getTilesFilename(year: number, manifest: TilesManifest): string | null {
+function getTilesFilename(year: number, manifest: TilesManifest): string | null {
   if (!isProductionTiles()) {
     return `world_${year}.pmtiles`;
   }


### PR DESCRIPTION
## 概要

フロントエンドのユーティリティモジュールからデッドコードを削除し、内部関数の `export` を外しました。

### 変更内容

- `color-scheme.ts` から未使用の `getColorForSubjecto` 関数を削除しました（プロダクションコードで使用されておらず、`createMatchColorExpression` で色の適用は完結しています）
- `tiles-config.ts` の `getTilesBaseUrl`・`isProductionTiles`・`getTilesFilename` から `export` を外しました（ファイル内部でのみ使用されていたため）
- 削除した関数に対応するテストも削除しました

## 動作確認

- [ ] `pnpm test` が全テストパスする
- [ ] `pnpm check` が Biome チェックパスする

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)