### PR TITLE
refactor(worker): improve code quality with CORS helper, cache constants, and better naming

### DIFF
--- a/apps/worker/src/index.ts
+++ b/apps/worker/src/index.ts
@@ -3,27 +3,36 @@ interface Env {
   BUCKET: R2Bucket;
 }
 
+const MANIFEST_CACHE_CONTROL = 'public, max-age=300';
+const NOT_FOUND_CACHE_CONTROL = 'public, max-age=60';
+const IMMUTABLE_CACHE_CONTROL = 'public, max-age=31536000, immutable';
+
+function matchesPattern(origin: string, pattern: string): boolean {
+  if (pattern === '*' || pattern === origin) {
+    return true;
+  }
+  if (pattern.includes('*')) {
+    const regex = new RegExp(`^${pattern.replace(/\./g, '\\.').replace('*', '[^.]+')}$`);
+    return regex.test(origin);
+  }
+  return false;
+}
+
 function getAllowedOrigin(request: Request, env: Env): string {
   const requestOrigin = request.headers.get('Origin');
   if (typeof env.ALLOWED_ORIGINS === 'undefined' || !requestOrigin) {
     return '';
   }
 
-  for (const pattern of env.ALLOWED_ORIGINS.split(',')) {
-    if (pattern === '*') {
-      return requestOrigin;
-    }
-    if (pattern === requestOrigin) {
-      return requestOrigin;
-    }
-    if (pattern.includes('*')) {
-      const regex: RegExp = new RegExp(`^${pattern.replace(/\./g, '\\.').replace('*', '[^.]+')}$`);
-      if (regex.test(requestOrigin)) {
-        return requestOrigin;
-      }
-    }
+  const patterns = env.ALLOWED_ORIGINS.split(',');
+  return patterns.some((pattern) => matchesPattern(requestOrigin, pattern)) ? requestOrigin : '';
+}
+
+function applyCorsHeaders(headers: Headers, allowedOrigin: string): void {
+  if (allowedOrigin) {
+    headers.set('Access-Control-Allow-Origin', allowedOrigin);
   }
-  return '';
+  headers.set('Vary', 'Origin');
 }
 
 async function handleManifest(
@@ -37,8 +46,7 @@ async function handleManifest(
   const cached = await cache.match(request.url);
   if (cached) {
     const respHeaders = new Headers(cached.headers);
-    if (allowedOrigin) respHeaders.set('Access-Control-Allow-Origin', allowedOrigin);
-    respHeaders.set('Vary', 'Origin');
+    applyCorsHeaders(respHeaders, allowedOrigin);
     return new Response(cached.body, { headers: respHeaders, status: cached.status });
   }
 
@@ -46,21 +54,19 @@ async function handleManifest(
   if (!obj) {
     const headers = new Headers();
     headers.set('Cache-Control', 'no-store');
-    if (allowedOrigin) headers.set('Access-Control-Allow-Origin', allowedOrigin);
-    headers.set('Vary', 'Origin');
+    applyCorsHeaders(headers, allowedOrigin);
     return new Response('Manifest not found', { headers, status: 404 });
   }
 
   const body = await obj.text();
   const headers = new Headers();
   headers.set('Content-Type', 'application/json');
-  headers.set('Cache-Control', 'public, max-age=300');
+  headers.set('Cache-Control', MANIFEST_CACHE_CONTROL);
 
   const cacheable = new Response(body, { headers, status: 200 });
   ctx.waitUntil(cache.put(request.url, cacheable.clone()));
 
-  if (allowedOrigin) headers.set('Access-Control-Allow-Origin', allowedOrigin);
-  headers.set('Vary', 'Origin');
+  applyCorsHeaders(headers, allowedOrigin);
 
   return new Response(body, { headers, status: 200 });
 }
@@ -87,9 +93,8 @@ async function handlePMTilesFile(request: Request, env: Env, filename: string): 
   if (!obj) {
     const headers = new Headers();
     // Short cache for 404 to prevent abuse while allowing quick recovery
-    headers.set('Cache-Control', 'public, max-age=60');
-    if (allowedOrigin) headers.set('Access-Control-Allow-Origin', allowedOrigin);
-    headers.set('Vary', 'Origin');
+    headers.set('Cache-Control', NOT_FOUND_CACHE_CONTROL);
+    applyCorsHeaders(headers, allowedOrigin);
     return new Response('File not found', { headers, status: 404 });
   }
 
@@ -97,14 +102,16 @@ async function handlePMTilesFile(request: Request, env: Env, filename: string): 
   headers.set('Content-Type', 'application/octet-stream');
   headers.set('Accept-Ranges', 'bytes');
   // PMTiles files are immutable (hash-based filenames)
-  headers.set('Cache-Control', 'public, max-age=31536000, immutable');
-  if (allowedOrigin) headers.set('Access-Control-Allow-Origin', allowedOrigin);
-  headers.set('Vary', 'Origin');
+  headers.set('Cache-Control', IMMUTABLE_CACHE_CONTROL);
+  applyCorsHeaders(headers, allowedOrigin);
 
   if (rangeHeader && obj.range) {
-    const r = obj.range as { offset: number; length: number };
-    headers.set('Content-Range', `bytes ${r.offset}-${r.offset + r.length - 1}/${obj.size}`);
-    headers.set('Content-Length', String(r.length));
+    const byteRange = obj.range as { offset: number; length: number };
+    headers.set(
+      'Content-Range',
+      `bytes ${byteRange.offset}-${byteRange.offset + byteRange.length - 1}/${obj.size}`,
+    );
+    headers.set('Content-Length', String(byteRange.length));
     return new Response(obj.body, { headers, status: 206 });
   }
 


### PR DESCRIPTION
## 概要

close #202

Worker (`apps/worker/src/index.ts`) のコード品質を改善するリファクタリングです。

### 背景

- CORS ヘッダー設定が `handleManifest` と `handlePMTilesFile` の複数箇所で重複していた
- Cache-Control 値がマジックナンバーとして直書きされており意図が読み取りにくかった
- `handlePMTilesFile` 内の1文字変数 `r` の可読性が低かった
- `getAllowedOrigin` が `for` + 多重 `if` でネストが深かった

### 変更内容

- `applyCorsHeaders()` を抽出し、CORS ヘッダー付与の重複を排除
- Cache-Control 値を名前付き定数に抽出 (`MANIFEST_CACHE_CONTROL`, `NOT_FOUND_CACHE_CONTROL`, `IMMUTABLE_CACHE_CONTROL`)
- 1文字変数 `r` を `byteRange` にリネーム
- `getAllowedOrigin` を `Array.prototype.some` + `matchesPattern` ヘルパー関数でフラットに書き換え

## 動作確認

- [ ] `pnpm test && pnpm check && pnpm typecheck` が通ること
- [ ] Worker のマニフェスト取得が正常に動作すること
- [ ] PMTiles ファイルの Range リクエストが正常に動作すること
- [ ] CORS ヘッダーが正しく付与されること

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
