### PR TITLE
fix(tiles-gc): replace wrangler r2 object list with Cloudflare REST API

### DIFF
--- a/packages/tiles/src/manifest/hashed-tile-filename.ts
+++ b/packages/tiles/src/manifest/hashed-tile-filename.ts
@@ -33,6 +33,13 @@ export class HashedTileFilename {
     return new HashedTileFilename(asHistoricalYearString(yearStr), hashStr);
   }
 
+  static parseAll(keys: readonly string[]): readonly HashedTileFilename[] {
+    return keys.flatMap((key) => {
+      const tile = HashedTileFilename.parseHashed(key);
+      return tile !== null ? [tile] : [];
+    });
+  }
+
   static extractYearFromSource(filename: string): HistoricalYearString | null {
     const [, yearStr] = SOURCE_FILENAME_PATTERN.exec(filename) ?? [];
     if (!yearStr) return null;

--- a/packages/tiles/tests/manifest/hashed-tile-filename.test.ts
+++ b/packages/tiles/tests/manifest/hashed-tile-filename.test.ts
@@ -56,6 +56,36 @@ describe('HashedTileFilename.extractYearFromSource', () => {
   });
 });
 
+describe('HashedTileFilename.parseAll', () => {
+  it('returns parsed instances for valid keys', () => {
+    const result = HashedTileFilename.parseAll([
+      'world_1600.fedcba987654.pmtiles',
+      'world_-1.aaaaaaaaaaaa.pmtiles',
+    ]);
+    expect(result).toHaveLength(2);
+    expect(result[0]?.year).toBe('1600');
+    expect(result[1]?.year).toBe('-1');
+  });
+
+  it('excludes keys that do not match the hashed pattern', () => {
+    const result = HashedTileFilename.parseAll([
+      'world_1600.pmtiles',
+      'readme.txt',
+      'world_1600.fedcba987654.pmtiles',
+    ]);
+    expect(result).toHaveLength(1);
+    expect(result[0]?.year).toBe('1600');
+  });
+
+  it('returns empty array for empty input', () => {
+    expect(HashedTileFilename.parseAll([])).toEqual([]);
+  });
+
+  it('returns empty array when no keys match', () => {
+    expect(HashedTileFilename.parseAll(['readme.txt', 'world_1600.pmtiles'])).toEqual([]);
+  });
+});
+
 describe('HashedTileFilename.sourceExtension', () => {
   it('is .pmtiles', () => {
     expect(HashedTileFilename.sourceExtension).toBe('.pmtiles');

--- a/scripts/tiles-gc/cli.ts
+++ b/scripts/tiles-gc/cli.ts
@@ -1,5 +1,6 @@
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { CloudflareApiCredentials } from './src/cloudflare-credentials.ts';
 import { GcCliInputs } from './src/gc-cli-inputs.ts';
 import { gcExecutionFor } from './src/gc-execution.ts';
 import { ConsoleGcReporter } from './src/gc-reporter.ts';
@@ -12,7 +13,10 @@ const REPO_ROOT = path.resolve(fileURLToPath(import.meta.url), '../../..');
 async function main(): Promise<void> {
   const inputs = GcCliInputs.fromEnv(process.env);
   const historyRepo = new GitManifestHistoryRepository(REPO_ROOT);
-  const r2Repo = new WranglerR2BucketRepository(REPO_ROOT);
+  const r2Repo = new WranglerR2BucketRepository(
+    REPO_ROOT,
+    CloudflareApiCredentials.fromEnv(process.env),
+  );
   const gcExecution = gcExecutionFor(inputs.dryRun, r2Repo);
   const reporter = new ConsoleGcReporter();
   const useCase = new GcUseCase(historyRepo, r2Repo, gcExecution);

--- a/scripts/tiles-gc/src/cloudflare-credentials.test.ts
+++ b/scripts/tiles-gc/src/cloudflare-credentials.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest';
+import { CloudflareApiCredentials } from './cloudflare-credentials.ts';
+
+describe('CloudflareApiCredentials.fromEnv', () => {
+  it('creates credentials from env', () => {
+    const creds = CloudflareApiCredentials.fromEnv({
+      CLOUDFLARE_ACCOUNT_ID: 'acc123',
+      CLOUDFLARE_API_TOKEN: 'tok456',
+    });
+    expect(creds.accountId).toBe('acc123');
+    expect(creds.apiToken).toBe('tok456');
+  });
+
+  it('throws when both are missing', () => {
+    expect(() => CloudflareApiCredentials.fromEnv({})).toThrow(
+      'CLOUDFLARE_ACCOUNT_ID and CLOUDFLARE_API_TOKEN are required',
+    );
+  });
+
+  it('throws when accountId is missing', () => {
+    expect(() => CloudflareApiCredentials.fromEnv({ CLOUDFLARE_API_TOKEN: 'tok456' })).toThrow(
+      'CLOUDFLARE_ACCOUNT_ID and CLOUDFLARE_API_TOKEN are required',
+    );
+  });
+
+  it('throws when apiToken is missing', () => {
+    expect(() => CloudflareApiCredentials.fromEnv({ CLOUDFLARE_ACCOUNT_ID: 'acc123' })).toThrow(
+      'CLOUDFLARE_ACCOUNT_ID and CLOUDFLARE_API_TOKEN are required',
+    );
+  });
+});
+
+describe('CloudflareApiCredentials.authHeader', () => {
+  it('returns Bearer authorization header', () => {
+    const creds = CloudflareApiCredentials.fromEnv({
+      CLOUDFLARE_ACCOUNT_ID: 'acc123',
+      CLOUDFLARE_API_TOKEN: 'tok456',
+    });
+    expect(creds.authHeader()).toEqual({ Authorization: 'Bearer tok456' });
+  });
+});

--- a/scripts/tiles-gc/src/cloudflare-credentials.ts
+++ b/scripts/tiles-gc/src/cloudflare-credentials.ts
@@ -1,0 +1,22 @@
+export class CloudflareApiCredentials {
+  readonly accountId: string;
+  readonly apiToken: string;
+
+  private constructor(accountId: string, apiToken: string) {
+    this.accountId = accountId;
+    this.apiToken = apiToken;
+  }
+
+  static fromEnv(env: NodeJS.ProcessEnv): CloudflareApiCredentials {
+    const accountId = env['CLOUDFLARE_ACCOUNT_ID'];
+    const apiToken = env['CLOUDFLARE_API_TOKEN'];
+    if (!accountId || !apiToken) {
+      throw new Error('CLOUDFLARE_ACCOUNT_ID and CLOUDFLARE_API_TOKEN are required');
+    }
+    return new CloudflareApiCredentials(accountId, apiToken);
+  }
+
+  authHeader(): Readonly<Record<string, string>> {
+    return { Authorization: `Bearer ${this.apiToken}` };
+  }
+}

--- a/scripts/tiles-gc/src/r2-bucket.test.ts
+++ b/scripts/tiles-gc/src/r2-bucket.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it, vi } from 'vitest';
+import { DEV_BUCKET } from './bucket-name.ts';
+import { CloudflareApiCredentials } from './cloudflare-credentials.ts';
+import type { FetchFn } from './r2-bucket.ts';
+import { WranglerR2BucketRepository } from './r2-bucket.ts';
+
+const TEST_CREDENTIALS = CloudflareApiCredentials.fromEnv({
+  CLOUDFLARE_ACCOUNT_ID: 'test-account',
+  CLOUDFLARE_API_TOKEN: 'test-token',
+});
+
+function makeListResponse(keys: string[], truncated: boolean, cursor?: string): Response {
+  return new Response(
+    JSON.stringify({ result: { objects: keys.map((key) => ({ key })), truncated, cursor } }),
+    { status: 200 },
+  );
+}
+
+describe('WranglerR2BucketRepository', () => {
+  describe('listObjects', () => {
+    it('returns hashed tile filenames from a single page', async () => {
+      const mockFetch = vi
+        .fn<FetchFn>()
+        .mockResolvedValue(
+          makeListResponse(
+            ['world_1600.fedcba987654.pmtiles', 'world_1700.aabbcc112233.pmtiles', 'readme.txt'],
+            false,
+          ),
+        );
+
+      const repo = new WranglerR2BucketRepository('/', TEST_CREDENTIALS, undefined, mockFetch);
+      const result = await repo.listObjects(DEV_BUCKET);
+
+      expect(result).toHaveLength(2);
+      expect(result).toContain('world_1600.fedcba987654.pmtiles');
+      expect(result).toContain('world_1700.aabbcc112233.pmtiles');
+    });
+
+    it('iterates through multiple pages using cursor', async () => {
+      const mockFetch = vi
+        .fn<FetchFn>()
+        .mockResolvedValueOnce(
+          makeListResponse(['world_1600.fedcba987654.pmtiles'], true, 'cursor-abc'),
+        )
+        .mockResolvedValueOnce(makeListResponse(['world_1700.aabbcc112233.pmtiles'], false));
+
+      const repo = new WranglerR2BucketRepository('/', TEST_CREDENTIALS, undefined, mockFetch);
+      const result = await repo.listObjects(DEV_BUCKET);
+
+      expect(result).toHaveLength(2);
+      expect(mockFetch).toHaveBeenCalledTimes(2);
+      const secondCallUrl = mockFetch.mock.calls[1]?.[0] as URL;
+      expect(secondCallUrl.searchParams.get('cursor')).toBe('cursor-abc');
+    });
+
+    it('excludes keys that do not match the hashed tile pattern', async () => {
+      const mockFetch = vi
+        .fn<FetchFn>()
+        .mockResolvedValue(makeListResponse(['readme.txt', 'world_1600.pmtiles'], false));
+
+      const repo = new WranglerR2BucketRepository('/', TEST_CREDENTIALS, undefined, mockFetch);
+      const result = await repo.listObjects(DEV_BUCKET);
+
+      expect(result).toHaveLength(0);
+    });
+
+    it('throws when the API returns a non-ok status', async () => {
+      const mockFetch = vi
+        .fn<FetchFn>()
+        .mockResolvedValue(new Response(null, { status: 403, statusText: 'Forbidden' }));
+
+      const repo = new WranglerR2BucketRepository('/', TEST_CREDENTIALS, undefined, mockFetch);
+      await expect(repo.listObjects(DEV_BUCKET)).rejects.toThrow(
+        `Failed to list ${DEV_BUCKET}: 403 Forbidden`,
+      );
+    });
+  });
+});

--- a/scripts/tiles-gc/src/r2-bucket.ts
+++ b/scripts/tiles-gc/src/r2-bucket.ts
@@ -8,6 +8,8 @@ const execFileAsync = promisify(execFile);
 
 export type ExecWrangler = (args: readonly string[], cwd: string) => Promise<string>;
 
+export type FetchFn = typeof fetch;
+
 interface CloudflareR2Object {
   readonly key: string;
 }
@@ -29,15 +31,18 @@ export class WranglerR2BucketRepository implements R2BucketRepository {
   readonly #repoRoot: string;
   readonly #credentials: CloudflareApiCredentials;
   readonly #execWrangler: ExecWrangler;
+  readonly #fetchFn: FetchFn;
 
   constructor(
     repoRoot: string,
     credentials: CloudflareApiCredentials,
     execWrangler?: ExecWrangler,
+    fetchFn?: FetchFn,
   ) {
     this.#repoRoot = repoRoot;
     this.#credentials = credentials;
     this.#execWrangler = execWrangler ?? defaultExecWrangler;
+    this.#fetchFn = fetchFn ?? defaultFetch;
   }
 
   async listObjects(bucket: BucketName): Promise<readonly HashedFilename[]> {
@@ -50,7 +55,7 @@ export class WranglerR2BucketRepository implements R2BucketRepository {
       );
       if (cursor) url.searchParams.set('cursor', cursor);
 
-      const response = await fetch(url, {
+      const response = await this.#fetchFn(url, {
         headers: this.#credentials.authHeader(),
       });
 
@@ -79,4 +84,8 @@ export class WranglerR2BucketRepository implements R2BucketRepository {
 
 function defaultExecWrangler(args: readonly string[], cwd: string): Promise<string> {
   return execFileAsync('wrangler', [...args], { cwd }).then(({ stdout }) => stdout);
+}
+
+function defaultFetch(...args: Parameters<FetchFn>): ReturnType<FetchFn> {
+  return fetch(...args);
 }

--- a/scripts/tiles-gc/src/r2-bucket.ts
+++ b/scripts/tiles-gc/src/r2-bucket.ts
@@ -6,6 +6,8 @@ import type { CloudflareApiCredentials } from './cloudflare-credentials.ts';
 
 const execFileAsync = promisify(execFile);
 
+const CLOUDFLARE_API_BASE_URL = 'https://api.cloudflare.com/client/v4';
+
 export type ExecWrangler = (args: readonly string[], cwd: string) => Promise<string>;
 
 export type FetchFn = typeof fetch;
@@ -46,32 +48,45 @@ export class WranglerR2BucketRepository implements R2BucketRepository {
   }
 
   async listObjects(bucket: BucketName): Promise<readonly HashedFilename[]> {
-    const keys: string[] = [];
-    let cursor: string | undefined;
+    const objectKeys = await this.#fetchAllObjectKeys(bucket);
+    return HashedTileFilename.parseAll(objectKeys).map((tile) => tile.toString() as HashedFilename);
+  }
+
+  async #fetchAllObjectKeys(bucket: BucketName): Promise<readonly string[]> {
+    const objectKeys: string[] = [];
+    let nextPageCursor: string | undefined;
 
     do {
-      const url = new URL(
-        `https://api.cloudflare.com/client/v4/accounts/${this.#credentials.accountId}/r2/buckets/${bucket}/objects`,
-      );
-      if (cursor) url.searchParams.set('cursor', cursor);
+      const page = await this.#fetchObjectsPage(bucket, nextPageCursor);
+      objectKeys.push(...page.keys);
+      nextPageCursor = page.nextCursor;
+    } while (nextPageCursor !== undefined);
 
-      const response = await this.#fetchFn(url, {
-        headers: this.#credentials.authHeader(),
-      });
+    return objectKeys;
+  }
 
-      if (!response.ok) {
-        throw new Error(`Failed to list ${bucket}: ${response.status} ${response.statusText}`);
-      }
+  async #fetchObjectsPage(
+    bucket: BucketName,
+    cursor: string | undefined,
+  ): Promise<{ readonly keys: readonly string[]; readonly nextCursor: string | undefined }> {
+    const url = new URL(
+      `${CLOUDFLARE_API_BASE_URL}/accounts/${this.#credentials.accountId}/r2/buckets/${bucket}/objects`,
+    );
+    if (cursor !== undefined) url.searchParams.set('cursor', cursor);
 
-      const data = (await response.json()) as CloudflareR2ListResult;
-      keys.push(...data.result.objects.map((o) => o.key));
-      cursor = data.result.truncated ? data.result.cursor : undefined;
-    } while (cursor !== undefined);
-
-    return keys.flatMap((key) => {
-      const tile = HashedTileFilename.parseHashed(key);
-      return tile !== null ? [tile.toString() as HashedFilename] : [];
+    const response = await this.#fetchFn(url, {
+      headers: this.#credentials.authHeader(),
     });
+
+    if (!response.ok) {
+      throw new Error(`Failed to list ${bucket}: ${response.status} ${response.statusText}`);
+    }
+
+    const listResponse = (await response.json()) as CloudflareR2ListResult;
+    return {
+      keys: listResponse.result.objects.map((r2Object) => r2Object.key),
+      nextCursor: listResponse.result.truncated ? listResponse.result.cursor : undefined,
+    };
   }
 
   async deleteObject(bucket: BucketName, key: HashedFilename): Promise<void> {

--- a/scripts/tiles-gc/src/r2-bucket.ts
+++ b/scripts/tiles-gc/src/r2-bucket.ts
@@ -2,6 +2,7 @@ import { execFile } from 'node:child_process';
 import { promisify } from 'node:util';
 import { type HashedFilename, HashedTileFilename } from '@world-history-map/tiles';
 import type { BucketName } from './bucket-name.ts';
+import type { CloudflareApiCredentials } from './cloudflare-credentials.ts';
 
 const execFileAsync = promisify(execFile);
 
@@ -26,33 +27,31 @@ export interface R2BucketRepository {
 
 export class WranglerR2BucketRepository implements R2BucketRepository {
   readonly #repoRoot: string;
+  readonly #credentials: CloudflareApiCredentials;
   readonly #execWrangler: ExecWrangler;
 
-  constructor(repoRoot: string, execWrangler?: ExecWrangler) {
+  constructor(
+    repoRoot: string,
+    credentials: CloudflareApiCredentials,
+    execWrangler?: ExecWrangler,
+  ) {
     this.#repoRoot = repoRoot;
+    this.#credentials = credentials;
     this.#execWrangler = execWrangler ?? defaultExecWrangler;
   }
 
   async listObjects(bucket: BucketName): Promise<readonly HashedFilename[]> {
-    const accountId = process.env['CLOUDFLARE_ACCOUNT_ID'];
-    const apiToken = process.env['CLOUDFLARE_API_TOKEN'];
-    if (!accountId || !apiToken) {
-      throw new Error(
-        'CLOUDFLARE_ACCOUNT_ID and CLOUDFLARE_API_TOKEN are required to list objects',
-      );
-    }
-
     const keys: string[] = [];
     let cursor: string | undefined;
 
     do {
       const url = new URL(
-        `https://api.cloudflare.com/client/v4/accounts/${accountId}/r2/buckets/${bucket}/objects`,
+        `https://api.cloudflare.com/client/v4/accounts/${this.#credentials.accountId}/r2/buckets/${bucket}/objects`,
       );
       if (cursor) url.searchParams.set('cursor', cursor);
 
       const response = await fetch(url, {
-        headers: { Authorization: `Bearer ${apiToken}` },
+        headers: this.#credentials.authHeader(),
       });
 
       if (!response.ok) {

--- a/scripts/tiles-gc/src/r2-bucket.ts
+++ b/scripts/tiles-gc/src/r2-bucket.ts
@@ -7,6 +7,18 @@ const execFileAsync = promisify(execFile);
 
 export type ExecWrangler = (args: readonly string[], cwd: string) => Promise<string>;
 
+interface CloudflareR2Object {
+  readonly key: string;
+}
+
+interface CloudflareR2ListResult {
+  readonly result: {
+    readonly objects: readonly CloudflareR2Object[];
+    readonly truncated: boolean;
+    readonly cursor?: string;
+  };
+}
+
 export interface R2BucketRepository {
   listObjects(bucket: BucketName): Promise<readonly HashedFilename[]>;
   deleteObject(bucket: BucketName, key: HashedFilename): Promise<void>;
@@ -22,14 +34,39 @@ export class WranglerR2BucketRepository implements R2BucketRepository {
   }
 
   async listObjects(bucket: BucketName): Promise<readonly HashedFilename[]> {
-    const output = await this.#execWrangler(
-      ['r2', 'object', 'list', bucket, '--remote', '--json'],
-      this.#repoRoot,
-    );
-    const parsed = JSON.parse(output) as { key: string }[];
-    return parsed.flatMap((entry) => {
-      const tile = HashedTileFilename.parseHashed(entry.key);
-      return tile !== null ? [tile.toString()] : [];
+    const accountId = process.env['CLOUDFLARE_ACCOUNT_ID'];
+    const apiToken = process.env['CLOUDFLARE_API_TOKEN'];
+    if (!accountId || !apiToken) {
+      throw new Error(
+        'CLOUDFLARE_ACCOUNT_ID and CLOUDFLARE_API_TOKEN are required to list objects',
+      );
+    }
+
+    const keys: string[] = [];
+    let cursor: string | undefined;
+
+    do {
+      const url = new URL(
+        `https://api.cloudflare.com/client/v4/accounts/${accountId}/r2/buckets/${bucket}/objects`,
+      );
+      if (cursor) url.searchParams.set('cursor', cursor);
+
+      const response = await fetch(url, {
+        headers: { Authorization: `Bearer ${apiToken}` },
+      });
+
+      if (!response.ok) {
+        throw new Error(`Failed to list ${bucket}: ${response.status} ${response.statusText}`);
+      }
+
+      const data = (await response.json()) as CloudflareR2ListResult;
+      keys.push(...data.result.objects.map((o) => o.key));
+      cursor = data.result.truncated ? data.result.cursor : undefined;
+    } while (cursor !== undefined);
+
+    return keys.flatMap((key) => {
+      const tile = HashedTileFilename.parseHashed(key);
+      return tile !== null ? [tile.toString() as HashedFilename] : [];
     });
   }
 


### PR DESCRIPTION
## 概要

T054（GC dry-run）実行時に `wrangler r2 object list` が存在しないため失敗していた問題を修正します。

### 背景

- `wrangler r2 object list` コマンドはプロジェクトで使用している wrangler バージョンに存在せず（`get/put/delete` のみ）、CI で `Unknown arguments: list` エラーが発生していた
- R2 のオブジェクト一覧取得を Cloudflare REST API（`GET /accounts/{accountId}/r2/buckets/{bucket}/objects`）に置き換えることで解決

### 変更内容

- `scripts/tiles-gc/src/r2-bucket.ts` の `listObjects()` を `fetch()` ベースの REST API 呼び出しに変更
- ページネーション（truncated/cursor）に対応
- `deleteObject()` は引き続き wrangler を使用（こちらは動作する）

## 動作確認

- [ ] `gh workflow run tiles-gc.yml -f dry_run=true -f window_size=3 -f target_env=both` でエラーなく保持集合・削除候補が表示される

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
