### PR TITLE
refactor(tiles-gc): split R2 repository into focused interfaces + zod validation

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -156,6 +156,9 @@ importers:
       '@world-history-map/tiles':
         specifier: workspace:*
         version: link:../../packages/tiles
+      zod:
+        specifier: ^4.3.6
+        version: 4.3.6
     devDependencies:
       '@types/node':
         specifier: ^25.5.0

--- a/scripts/tiles-gc/cli.ts
+++ b/scripts/tiles-gc/cli.ts
@@ -6,20 +6,19 @@ import { gcExecutionFor } from './src/gc-execution.ts';
 import { ConsoleGcReporter } from './src/gc-reporter.ts';
 import { GcUseCase } from './src/gc-use-case.ts';
 import { GitManifestHistoryRepository } from './src/manifest-history.ts';
-import { WranglerR2BucketRepository } from './src/r2-bucket.ts';
+import { WranglerObjectDeleter } from './src/r2-object-deleter.ts';
+import { CloudflareApiObjectLister } from './src/r2-object-lister.ts';
 
 const REPO_ROOT = path.resolve(fileURLToPath(import.meta.url), '../../..');
 
 async function main(): Promise<void> {
   const inputs = GcCliInputs.fromEnv(process.env);
   const historyRepo = new GitManifestHistoryRepository(REPO_ROOT);
-  const r2Repo = new WranglerR2BucketRepository(
-    REPO_ROOT,
-    CloudflareApiCredentials.fromEnv(process.env),
-  );
-  const gcExecution = gcExecutionFor(inputs.dryRun, r2Repo);
+  const objectLister = new CloudflareApiObjectLister(CloudflareApiCredentials.fromEnv(process.env));
+  const objectDeleter = new WranglerObjectDeleter(REPO_ROOT);
+  const gcExecution = gcExecutionFor(inputs.dryRun, objectDeleter);
   const reporter = new ConsoleGcReporter();
-  const useCase = new GcUseCase(historyRepo, r2Repo, gcExecution);
+  const useCase = new GcUseCase(historyRepo, objectLister, gcExecution);
 
   const outcome = await useCase.run(inputs);
 

--- a/scripts/tiles-gc/cli.ts
+++ b/scripts/tiles-gc/cli.ts
@@ -13,12 +13,12 @@ const REPO_ROOT = path.resolve(fileURLToPath(import.meta.url), '../../..');
 
 async function main(): Promise<void> {
   const inputs = GcCliInputs.fromEnv(process.env);
-  const historyRepo = new GitManifestHistoryRepository(REPO_ROOT);
+  const historyRepository = new GitManifestHistoryRepository(REPO_ROOT);
   const objectLister = new CloudflareApiObjectLister(CloudflareApiCredentials.fromEnv(process.env));
   const objectDeleter = new WranglerObjectDeleter(REPO_ROOT);
   const gcExecution = gcExecutionFor(inputs.dryRun, objectDeleter);
   const reporter = new ConsoleGcReporter();
-  const useCase = new GcUseCase(historyRepo, objectLister, gcExecution);
+  const useCase = new GcUseCase(historyRepository, objectLister, gcExecution);
 
   const outcome = await useCase.run(inputs);
 

--- a/scripts/tiles-gc/package.json
+++ b/scripts/tiles-gc/package.json
@@ -9,7 +9,8 @@
     "test:coverage": "vitest run --coverage"
   },
   "dependencies": {
-    "@world-history-map/tiles": "workspace:*"
+    "@world-history-map/tiles": "workspace:*",
+    "zod": "^4.3.6"
   },
   "devDependencies": {
     "@types/node": "^25.5.0",

--- a/scripts/tiles-gc/src/cloudflare-credentials.test.ts
+++ b/scripts/tiles-gc/src/cloudflare-credentials.test.ts
@@ -1,16 +1,8 @@
 import { describe, expect, it } from 'vitest';
+import { DEV_BUCKET } from './bucket-name.ts';
 import { CloudflareApiCredentials } from './cloudflare-credentials.ts';
 
 describe('CloudflareApiCredentials.fromEnv', () => {
-  it('creates credentials from env', () => {
-    const creds = CloudflareApiCredentials.fromEnv({
-      CLOUDFLARE_ACCOUNT_ID: 'acc123',
-      CLOUDFLARE_API_TOKEN: 'tok456',
-    });
-    expect(creds.accountId).toBe('acc123');
-    expect(creds.apiToken).toBe('tok456');
-  });
-
   it('throws when both are missing', () => {
     expect(() => CloudflareApiCredentials.fromEnv({})).toThrow(
       'CLOUDFLARE_ACCOUNT_ID and CLOUDFLARE_API_TOKEN are required',
@@ -37,5 +29,28 @@ describe('CloudflareApiCredentials.authHeader', () => {
       CLOUDFLARE_API_TOKEN: 'tok456',
     });
     expect(creds.authHeader()).toEqual({ Authorization: 'Bearer tok456' });
+  });
+});
+
+describe('CloudflareApiCredentials.r2ListUrl', () => {
+  const creds = CloudflareApiCredentials.fromEnv({
+    CLOUDFLARE_ACCOUNT_ID: 'acc123',
+    CLOUDFLARE_API_TOKEN: 'tok456',
+  });
+
+  it('includes account id and bucket name in the path', () => {
+    const url = creds.r2ListUrl(DEV_BUCKET);
+    expect(url.pathname).toContain('acc123');
+    expect(url.pathname).toContain(DEV_BUCKET);
+  });
+
+  it('returns a URL without cursor param when cursor is not provided', () => {
+    const url = creds.r2ListUrl(DEV_BUCKET);
+    expect(url.searchParams.get('cursor')).toBeNull();
+  });
+
+  it('sets cursor search param when cursor is provided', () => {
+    const url = creds.r2ListUrl(DEV_BUCKET, 'page2');
+    expect(url.searchParams.get('cursor')).toBe('page2');
   });
 });

--- a/scripts/tiles-gc/src/cloudflare-credentials.ts
+++ b/scripts/tiles-gc/src/cloudflare-credentials.ts
@@ -1,10 +1,14 @@
+import type { BucketName } from './bucket-name.ts';
+
+const CLOUDFLARE_API_BASE_URL = 'https://api.cloudflare.com/client/v4';
+
 export class CloudflareApiCredentials {
-  readonly accountId: string;
-  readonly apiToken: string;
+  readonly #accountId: string;
+  readonly #apiToken: string;
 
   private constructor(accountId: string, apiToken: string) {
-    this.accountId = accountId;
-    this.apiToken = apiToken;
+    this.#accountId = accountId;
+    this.#apiToken = apiToken;
   }
 
   static fromEnv(env: NodeJS.ProcessEnv): CloudflareApiCredentials {
@@ -17,6 +21,14 @@ export class CloudflareApiCredentials {
   }
 
   authHeader(): Readonly<Record<string, string>> {
-    return { Authorization: `Bearer ${this.apiToken}` };
+    return { Authorization: `Bearer ${this.#apiToken}` };
+  }
+
+  r2ListUrl(bucket: BucketName, cursor?: string): URL {
+    const url = new URL(
+      `${CLOUDFLARE_API_BASE_URL}/accounts/${this.#accountId}/r2/buckets/${bucket}/objects`,
+    );
+    if (cursor !== undefined) url.searchParams.set('cursor', cursor);
+    return url;
   }
 }

--- a/scripts/tiles-gc/src/deletion-plan.ts
+++ b/scripts/tiles-gc/src/deletion-plan.ts
@@ -20,6 +20,6 @@ export class DeletionPlan {
   }
 
   candidates(): readonly HashedFilename[] {
-    return this.#keys;
+    return [...this.#keys];
   }
 }

--- a/scripts/tiles-gc/src/gc-execution.ts
+++ b/scripts/tiles-gc/src/gc-execution.ts
@@ -1,6 +1,6 @@
 import type { BucketName } from './bucket-name.ts';
 import type { DeletionPlan } from './deletion-plan.ts';
-import type { R2BucketRepository } from './r2-bucket.ts';
+import type { R2ObjectDeleter } from './r2-object-deleter.ts';
 
 export interface GcExecutionResult {
   readonly deleted: number;
@@ -18,20 +18,20 @@ export class DryRunGcExecution implements GcExecution {
 }
 
 export class LiveGcExecution implements GcExecution {
-  readonly #r2Repo: R2BucketRepository;
+  readonly #objectDeleter: R2ObjectDeleter;
 
-  constructor(r2Repo: R2BucketRepository) {
-    this.#r2Repo = r2Repo;
+  constructor(objectDeleter: R2ObjectDeleter) {
+    this.#objectDeleter = objectDeleter;
   }
 
   async execute(bucket: BucketName, plan: DeletionPlan): Promise<GcExecutionResult> {
     for (const key of plan.candidates()) {
-      await this.#r2Repo.deleteObject(bucket, key);
+      await this.#objectDeleter.delete(bucket, key);
     }
     return { deleted: plan.size, mode: 'live' };
   }
 }
 
-export function gcExecutionFor(dryRun: boolean, r2Repo: R2BucketRepository): GcExecution {
-  return dryRun ? new DryRunGcExecution() : new LiveGcExecution(r2Repo);
+export function gcExecutionFor(dryRun: boolean, objectDeleter: R2ObjectDeleter): GcExecution {
+  return dryRun ? new DryRunGcExecution() : new LiveGcExecution(objectDeleter);
 }

--- a/scripts/tiles-gc/src/gc-use-case.ts
+++ b/scripts/tiles-gc/src/gc-use-case.ts
@@ -1,7 +1,11 @@
 import type { HashedFilename } from '@world-history-map/tiles';
 import type { BucketName } from './bucket-name.ts';
 import type { DeletionPlan } from './deletion-plan.ts';
-import { computeDeletionCandidates, computeRetainedHashes } from './gc.ts';
+import {
+  computeDeletionCandidates,
+  computeRetainedHashes,
+  extractHashedTileFilenames,
+} from './gc.ts';
 import type { GcCliInputs } from './gc-cli-inputs.ts';
 import type { GcExecution, GcExecutionResult } from './gc-execution.ts';
 import type { ManifestHistoryRepository } from './manifest-history.ts';
@@ -41,8 +45,9 @@ export class GcUseCase {
 
     const buckets: BucketGcOutcome[] = [];
     for (const bucket of inputs.target.buckets()) {
-      const bucketObjects = await this.#objectLister.list(bucket);
-      const plan = computeDeletionCandidates(retained, bucketObjects);
+      const objectKeys = await this.#objectLister.list(bucket);
+      const hashedTiles = extractHashedTileFilenames(objectKeys);
+      const plan = computeDeletionCandidates(retained, hashedTiles);
       const executionResult = await this.#gcExecution.execute(bucket, plan);
       buckets.push({ bucket, retained, plan, executionResult });
     }

--- a/scripts/tiles-gc/src/gc-use-case.ts
+++ b/scripts/tiles-gc/src/gc-use-case.ts
@@ -1,26 +1,22 @@
-import type { HashedFilename } from '@world-history-map/tiles';
 import type { BucketName } from './bucket-name.ts';
 import type { DeletionPlan } from './deletion-plan.ts';
-import {
-  computeDeletionCandidates,
-  computeRetainedHashes,
-  extractHashedTileFilenames,
-} from './gc.ts';
+import { extractHashedTileFilenames } from './gc.ts';
 import type { GcCliInputs } from './gc-cli-inputs.ts';
 import type { GcExecution, GcExecutionResult } from './gc-execution.ts';
 import type { ManifestHistoryRepository } from './manifest-history.ts';
 import type { R2ObjectLister } from './r2-object-lister.ts';
+import { RetainedHashes } from './retained-hashes.ts';
 
 export interface BucketGcOutcome {
   readonly bucket: BucketName;
-  readonly retained: ReadonlySet<HashedFilename>;
+  readonly retained: RetainedHashes;
   readonly plan: DeletionPlan;
   readonly executionResult: GcExecutionResult;
 }
 
 export interface GcRunOutcome {
   readonly inputs: GcCliInputs;
-  readonly retained: ReadonlySet<HashedFilename>;
+  readonly retained: RetainedHashes;
   readonly buckets: readonly BucketGcOutcome[];
 }
 
@@ -41,13 +37,13 @@ export class GcUseCase {
 
   async run(inputs: GcCliInputs): Promise<GcRunOutcome> {
     const snapshots = await this.#historyRepository.recentSnapshots(inputs.windowSize);
-    const retained = computeRetainedHashes(snapshots);
+    const retained = RetainedHashes.fromSnapshots(snapshots);
 
     const buckets: BucketGcOutcome[] = [];
     for (const bucket of inputs.target.buckets()) {
       const objectKeys = await this.#objectLister.list(bucket);
       const hashedTiles = extractHashedTileFilenames(objectKeys);
-      const plan = computeDeletionCandidates(retained, hashedTiles);
+      const plan = retained.difference(hashedTiles);
       const executionResult = await this.#gcExecution.execute(bucket, plan);
       buckets.push({ bucket, retained, plan, executionResult });
     }

--- a/scripts/tiles-gc/src/gc-use-case.ts
+++ b/scripts/tiles-gc/src/gc-use-case.ts
@@ -5,7 +5,7 @@ import { computeDeletionCandidates, computeRetainedHashes } from './gc.ts';
 import type { GcCliInputs } from './gc-cli-inputs.ts';
 import type { GcExecution, GcExecutionResult } from './gc-execution.ts';
 import type { ManifestHistoryRepository } from './manifest-history.ts';
-import type { R2BucketRepository } from './r2-bucket.ts';
+import type { R2ObjectLister } from './r2-object-lister.ts';
 
 export interface BucketGcOutcome {
   readonly bucket: BucketName;
@@ -22,16 +22,16 @@ export interface GcRunOutcome {
 
 export class GcUseCase {
   readonly #historyRepo: ManifestHistoryRepository;
-  readonly #r2Repo: R2BucketRepository;
+  readonly #objectLister: R2ObjectLister;
   readonly #gcExecution: GcExecution;
 
   constructor(
     historyRepo: ManifestHistoryRepository,
-    r2Repo: R2BucketRepository,
+    objectLister: R2ObjectLister,
     gcExecution: GcExecution,
   ) {
     this.#historyRepo = historyRepo;
-    this.#r2Repo = r2Repo;
+    this.#objectLister = objectLister;
     this.#gcExecution = gcExecution;
   }
 
@@ -41,7 +41,7 @@ export class GcUseCase {
 
     const buckets: BucketGcOutcome[] = [];
     for (const bucket of inputs.target.buckets()) {
-      const bucketObjects = await this.#r2Repo.listObjects(bucket);
+      const bucketObjects = await this.#objectLister.list(bucket);
       const plan = computeDeletionCandidates(retained, bucketObjects);
       const executionResult = await this.#gcExecution.execute(bucket, plan);
       buckets.push({ bucket, retained, plan, executionResult });

--- a/scripts/tiles-gc/src/gc-use-case.ts
+++ b/scripts/tiles-gc/src/gc-use-case.ts
@@ -21,22 +21,22 @@ export interface GcRunOutcome {
 }
 
 export class GcUseCase {
-  readonly #historyRepo: ManifestHistoryRepository;
+  readonly #historyRepository: ManifestHistoryRepository;
   readonly #objectLister: R2ObjectLister;
   readonly #gcExecution: GcExecution;
 
   constructor(
-    historyRepo: ManifestHistoryRepository,
+    historyRepository: ManifestHistoryRepository,
     objectLister: R2ObjectLister,
     gcExecution: GcExecution,
   ) {
-    this.#historyRepo = historyRepo;
+    this.#historyRepository = historyRepository;
     this.#objectLister = objectLister;
     this.#gcExecution = gcExecution;
   }
 
   async run(inputs: GcCliInputs): Promise<GcRunOutcome> {
-    const snapshots = await this.#historyRepo.recentSnapshots(inputs.windowSize);
+    const snapshots = await this.#historyRepository.recentSnapshots(inputs.windowSize);
     const retained = computeRetainedHashes(snapshots);
 
     const buckets: BucketGcOutcome[] = [];

--- a/scripts/tiles-gc/src/gc.test.ts
+++ b/scripts/tiles-gc/src/gc.test.ts
@@ -2,7 +2,11 @@ import { asHashedFilename, type HashedFilename, TilesManifest } from '@world-his
 import { describe, expect, it, vi } from 'vitest';
 import { DEV_BUCKET } from './bucket-name.ts';
 import { DeletionPlan } from './deletion-plan.ts';
-import { computeDeletionCandidates, computeRetainedHashes } from './gc.ts';
+import {
+  computeDeletionCandidates,
+  computeRetainedHashes,
+  extractHashedTileFilenames,
+} from './gc.ts';
 import { DryRunGcExecution, LiveGcExecution } from './gc-execution.ts';
 import type { R2ObjectDeleter } from './r2-object-deleter.ts';
 
@@ -79,6 +83,25 @@ describe('computeDeletionCandidates', () => {
       asHashedFilename('world_1700.bbb.pmtiles'),
     ];
     expect(computeDeletionCandidates(retained, bucketObjects).size).toBe(2);
+  });
+});
+
+describe('extractHashedTileFilenames', () => {
+  it('returns only keys that match the hashed tile pattern', () => {
+    const keys = [
+      'world_1600.fedcba987654.pmtiles',
+      'readme.txt',
+      'world_1700.pmtiles',
+      'world_1800.aabbcc112233.pmtiles',
+    ];
+    const result = extractHashedTileFilenames(keys);
+    expect(result).toHaveLength(2);
+    expect(result).toContain('world_1600.fedcba987654.pmtiles');
+    expect(result).toContain('world_1800.aabbcc112233.pmtiles');
+  });
+
+  it('returns empty array when no keys match', () => {
+    expect(extractHashedTileFilenames(['readme.txt', 'world_1600.pmtiles'])).toHaveLength(0);
   });
 });
 

--- a/scripts/tiles-gc/src/gc.test.ts
+++ b/scripts/tiles-gc/src/gc.test.ts
@@ -4,7 +4,7 @@ import { DEV_BUCKET } from './bucket-name.ts';
 import { DeletionPlan } from './deletion-plan.ts';
 import { computeDeletionCandidates, computeRetainedHashes } from './gc.ts';
 import { DryRunGcExecution, LiveGcExecution } from './gc-execution.ts';
-import type { R2BucketRepository } from './r2-bucket.ts';
+import type { R2ObjectDeleter } from './r2-object-deleter.ts';
 
 describe('computeRetainedHashes', () => {
   it('returns union of hashed filenames from all manifest snapshots', () => {
@@ -95,19 +95,18 @@ describe('DryRunGcExecution', () => {
 });
 
 describe('LiveGcExecution', () => {
-  it('calls deleteObject for each candidate and returns deleted count', async () => {
-    const mockR2Repo: R2BucketRepository = {
-      listObjects: vi.fn(),
-      deleteObject: vi.fn().mockResolvedValue(undefined),
+  it('calls delete for each candidate and returns deleted count', async () => {
+    const mockObjectDeleter: R2ObjectDeleter = {
+      delete: vi.fn().mockResolvedValue(undefined),
     };
-    const execution = new LiveGcExecution(mockR2Repo);
+    const execution = new LiveGcExecution(mockObjectDeleter);
     const orphanKey = asHashedFilename('world_1600.orphan.pmtiles');
     const plan = DeletionPlan.fromCandidates([orphanKey]);
 
     const result = await execution.execute(DEV_BUCKET, plan);
 
-    expect(mockR2Repo.deleteObject).toHaveBeenCalledWith(DEV_BUCKET, orphanKey);
-    expect(mockR2Repo.deleteObject).toHaveBeenCalledTimes(1);
+    expect(mockObjectDeleter.delete).toHaveBeenCalledWith(DEV_BUCKET, orphanKey);
+    expect(mockObjectDeleter.delete).toHaveBeenCalledTimes(1);
     expect(result.deleted).toBe(1);
     expect(result.mode).toBe('live');
   });

--- a/scripts/tiles-gc/src/gc.test.ts
+++ b/scripts/tiles-gc/src/gc.test.ts
@@ -2,15 +2,12 @@ import { asHashedFilename, type HashedFilename, TilesManifest } from '@world-his
 import { describe, expect, it, vi } from 'vitest';
 import { DEV_BUCKET } from './bucket-name.ts';
 import { DeletionPlan } from './deletion-plan.ts';
-import {
-  computeDeletionCandidates,
-  computeRetainedHashes,
-  extractHashedTileFilenames,
-} from './gc.ts';
+import { extractHashedTileFilenames } from './gc.ts';
 import { DryRunGcExecution, LiveGcExecution } from './gc-execution.ts';
 import type { R2ObjectDeleter } from './r2-object-deleter.ts';
+import { RetainedHashes } from './retained-hashes.ts';
 
-describe('computeRetainedHashes', () => {
+describe('RetainedHashes.fromSnapshots', () => {
   it('returns union of hashed filenames from all manifest snapshots', () => {
     const snapshots = [
       TilesManifest.fromRecord({
@@ -22,7 +19,7 @@ describe('computeRetainedHashes', () => {
         '1700': 'world_1700.bbb222.pmtiles',
       }),
     ];
-    const retained = computeRetainedHashes(snapshots);
+    const retained = RetainedHashes.fromSnapshots(snapshots);
     expect(retained.has(asHashedFilename('world_1600.aaa111.pmtiles'))).toBe(true);
     expect(retained.has(asHashedFilename('world_1600.ccc333.pmtiles'))).toBe(true);
     expect(retained.has(asHashedFilename('world_1700.bbb222.pmtiles'))).toBe(true);
@@ -30,12 +27,12 @@ describe('computeRetainedHashes', () => {
   });
 
   it('returns empty set when no snapshots are provided', () => {
-    expect(computeRetainedHashes([]).size).toBe(0);
+    expect(RetainedHashes.fromSnapshots([]).size).toBe(0);
   });
 
   it('handles a single snapshot', () => {
     const snapshots = [TilesManifest.fromRecord({ '1600': 'world_1600.abc123.pmtiles' })];
-    const retained = computeRetainedHashes(snapshots);
+    const retained = RetainedHashes.fromSnapshots(snapshots);
     expect(retained.has(asHashedFilename('world_1600.abc123.pmtiles'))).toBe(true);
     expect(retained.size).toBe(1);
   });
@@ -46,43 +43,46 @@ describe('computeRetainedHashes', () => {
       TilesManifest.fromRecord({ '1600': 'world_1600.same.pmtiles' }),
       TilesManifest.fromRecord({ '1600': 'world_1600.same.pmtiles' }),
     ];
-    expect(computeRetainedHashes(snapshots).size).toBe(1);
+    expect(RetainedHashes.fromSnapshots(snapshots).size).toBe(1);
   });
 });
 
-describe('computeDeletionCandidates', () => {
+describe('RetainedHashes#difference', () => {
   it('returns objects not in the retained set', () => {
-    const retained = new Set([
-      asHashedFilename('world_1600.aaa111.pmtiles'),
-      asHashedFilename('world_1700.bbb222.pmtiles'),
+    const retained = RetainedHashes.fromSnapshots([
+      TilesManifest.fromRecord({
+        '1600': 'world_1600.aaa111.pmtiles',
+        '1700': 'world_1700.bbb222.pmtiles',
+      }),
     ]);
-    const bucketObjects: HashedFilename[] = [
+    const candidates: HashedFilename[] = [
       asHashedFilename('world_1600.aaa111.pmtiles'),
       asHashedFilename('world_1600.old000.pmtiles'),
       asHashedFilename('world_1700.bbb222.pmtiles'),
       asHashedFilename('world_1900.orphan.pmtiles'),
     ];
-    const plan = computeDeletionCandidates(retained, bucketObjects);
-    const candidates = plan.candidates();
-    expect(candidates).toContain(asHashedFilename('world_1600.old000.pmtiles'));
-    expect(candidates).toContain(asHashedFilename('world_1900.orphan.pmtiles'));
-    expect(candidates).not.toContain(asHashedFilename('world_1600.aaa111.pmtiles'));
-    expect(candidates).not.toContain(asHashedFilename('world_1700.bbb222.pmtiles'));
+    const plan = retained.difference(candidates);
+    const keys = plan.candidates();
+    expect(keys).toContain(asHashedFilename('world_1600.old000.pmtiles'));
+    expect(keys).toContain(asHashedFilename('world_1900.orphan.pmtiles'));
+    expect(keys).not.toContain(asHashedFilename('world_1600.aaa111.pmtiles'));
+    expect(keys).not.toContain(asHashedFilename('world_1700.bbb222.pmtiles'));
   });
 
   it('returns empty plan when all objects are retained', () => {
-    const retained = new Set([asHashedFilename('world_1600.aaa.pmtiles')]);
-    const bucketObjects: HashedFilename[] = [asHashedFilename('world_1600.aaa.pmtiles')];
-    expect(computeDeletionCandidates(retained, bucketObjects).size).toBe(0);
+    const retained = RetainedHashes.fromSnapshots([
+      TilesManifest.fromRecord({ '1600': 'world_1600.aaa.pmtiles' }),
+    ]);
+    expect(retained.difference([asHashedFilename('world_1600.aaa.pmtiles')]).size).toBe(0);
   });
 
   it('returns all objects when retained set is empty', () => {
-    const retained = new Set<HashedFilename>();
-    const bucketObjects: HashedFilename[] = [
+    const retained = RetainedHashes.fromSnapshots([]);
+    const candidates: HashedFilename[] = [
       asHashedFilename('world_1600.aaa.pmtiles'),
       asHashedFilename('world_1700.bbb.pmtiles'),
     ];
-    expect(computeDeletionCandidates(retained, bucketObjects).size).toBe(2);
+    expect(retained.difference(candidates).size).toBe(2);
   });
 });
 
@@ -138,7 +138,7 @@ describe('LiveGcExecution', () => {
 describe('window size boundary conditions', () => {
   it('N=1: retains only the single most recent manifest', () => {
     const snapshots = [TilesManifest.fromRecord({ '1600': 'world_1600.newest.pmtiles' })];
-    const retained = computeRetainedHashes(snapshots);
+    const retained = RetainedHashes.fromSnapshots(snapshots);
     expect(retained.has(asHashedFilename('world_1600.newest.pmtiles'))).toBe(true);
     expect(retained.size).toBe(1);
   });
@@ -149,7 +149,7 @@ describe('window size boundary conditions', () => {
       TilesManifest.fromRecord({ '1600': 'world_1600.v2.pmtiles' }),
       TilesManifest.fromRecord({ '1600': 'world_1600.v1.pmtiles' }),
     ];
-    const retained = computeRetainedHashes(snapshots);
+    const retained = RetainedHashes.fromSnapshots(snapshots);
     expect(retained.size).toBe(3);
     expect(retained.has(asHashedFilename('world_1600.v1.pmtiles'))).toBe(true);
     expect(retained.has(asHashedFilename('world_1600.v3.pmtiles'))).toBe(true);
@@ -159,13 +159,13 @@ describe('window size boundary conditions', () => {
     const snapshots = Array.from({ length: 10 }, (_, i) =>
       TilesManifest.fromRecord({ '1600': `world_1600.v${i.toString().padStart(2, '0')}.pmtiles` }),
     );
-    const retained = computeRetainedHashes(snapshots);
+    const retained = RetainedHashes.fromSnapshots(snapshots);
     expect(retained.size).toBe(10);
   });
 
   it('N exceeds history: returns all available snapshots without error', () => {
     const snapshots = [TilesManifest.fromRecord({ '1600': 'world_1600.only.pmtiles' })];
-    const retained = computeRetainedHashes(snapshots);
+    const retained = RetainedHashes.fromSnapshots(snapshots);
     expect(retained.size).toBe(1);
   });
 });

--- a/scripts/tiles-gc/src/gc.ts
+++ b/scripts/tiles-gc/src/gc.ts
@@ -1,4 +1,8 @@
-import type { HashedFilename, TilesManifest } from '@world-history-map/tiles';
+import {
+  type HashedFilename,
+  HashedTileFilename,
+  type TilesManifest,
+} from '@world-history-map/tiles';
 import { DeletionPlan } from './deletion-plan.ts';
 
 export function computeRetainedHashes(
@@ -22,4 +26,8 @@ export function computeDeletionCandidates(
 ): DeletionPlan {
   const candidates = bucketObjects.filter((key) => !retained.has(key));
   return DeletionPlan.fromCandidates(candidates);
+}
+
+export function extractHashedTileFilenames(keys: readonly string[]): readonly HashedFilename[] {
+  return HashedTileFilename.parseAll(keys).map((tile) => tile.toString());
 }

--- a/scripts/tiles-gc/src/gc.ts
+++ b/scripts/tiles-gc/src/gc.ts
@@ -1,32 +1,4 @@
-import {
-  type HashedFilename,
-  HashedTileFilename,
-  type TilesManifest,
-} from '@world-history-map/tiles';
-import { DeletionPlan } from './deletion-plan.ts';
-
-export function computeRetainedHashes(
-  snapshots: readonly TilesManifest[],
-): ReadonlySet<HashedFilename> {
-  const retained = new Set<HashedFilename>();
-  for (const manifest of snapshots) {
-    for (const year of manifest.availableYears()) {
-      const filename = manifest.filenameFor(year);
-      if (filename) {
-        retained.add(filename);
-      }
-    }
-  }
-  return retained;
-}
-
-export function computeDeletionCandidates(
-  retained: ReadonlySet<HashedFilename>,
-  bucketObjects: readonly HashedFilename[],
-): DeletionPlan {
-  const candidates = bucketObjects.filter((key) => !retained.has(key));
-  return DeletionPlan.fromCandidates(candidates);
-}
+import { type HashedFilename, HashedTileFilename } from '@world-history-map/tiles';
 
 export function extractHashedTileFilenames(keys: readonly string[]): readonly HashedFilename[] {
   return HashedTileFilename.parseAll(keys).map((tile) => tile.toString());

--- a/scripts/tiles-gc/src/r2-object-deleter.test.ts
+++ b/scripts/tiles-gc/src/r2-object-deleter.test.ts
@@ -1,0 +1,33 @@
+import { asHashedFilename } from '@world-history-map/tiles';
+import { describe, expect, it, vi } from 'vitest';
+import { DEV_BUCKET } from './bucket-name.ts';
+import type { ExecWrangler } from './r2-object-deleter.ts';
+import { WranglerObjectDeleter } from './r2-object-deleter.ts';
+
+describe('WranglerObjectDeleter', () => {
+  describe('delete', () => {
+    it('calls wrangler with the correct arguments', async () => {
+      const mockExecWrangler = vi.fn<ExecWrangler>().mockResolvedValue('');
+      const deleter = new WranglerObjectDeleter('/repo/root', mockExecWrangler);
+      const key = asHashedFilename('world_1600.fedcba987654.pmtiles');
+
+      await deleter.delete(DEV_BUCKET, key);
+
+      expect(mockExecWrangler).toHaveBeenCalledWith(
+        ['r2', 'object', 'delete', `${DEV_BUCKET}/${key}`, '--remote'],
+        '/repo/root',
+      );
+    });
+
+    it('propagates errors from execWrangler', async () => {
+      const mockExecWrangler = vi
+        .fn<ExecWrangler>()
+        .mockRejectedValue(new Error('wrangler failed'));
+      const deleter = new WranglerObjectDeleter('/repo/root', mockExecWrangler);
+
+      await expect(
+        deleter.delete(DEV_BUCKET, asHashedFilename('world_1600.fedcba987654.pmtiles')),
+      ).rejects.toThrow('wrangler failed');
+    });
+  });
+});

--- a/scripts/tiles-gc/src/r2-object-deleter.ts
+++ b/scripts/tiles-gc/src/r2-object-deleter.ts
@@ -1,0 +1,33 @@
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+import type { HashedFilename } from '@world-history-map/tiles';
+import type { BucketName } from './bucket-name.ts';
+
+const execFileAsync = promisify(execFile);
+
+export type ExecWrangler = (args: readonly string[], cwd: string) => Promise<string>;
+
+export interface R2ObjectDeleter {
+  delete(bucket: BucketName, key: HashedFilename): Promise<void>;
+}
+
+export class WranglerObjectDeleter implements R2ObjectDeleter {
+  readonly #repoRoot: string;
+  readonly #execWrangler: ExecWrangler;
+
+  constructor(repoRoot: string, execWrangler?: ExecWrangler) {
+    this.#repoRoot = repoRoot;
+    this.#execWrangler = execWrangler ?? defaultExecWrangler;
+  }
+
+  async delete(bucket: BucketName, key: HashedFilename): Promise<void> {
+    await this.#execWrangler(
+      ['r2', 'object', 'delete', `${bucket}/${key}`, '--remote'],
+      this.#repoRoot,
+    );
+  }
+}
+
+function defaultExecWrangler(args: readonly string[], cwd: string): Promise<string> {
+  return execFileAsync('wrangler', [...args], { cwd }).then(({ stdout }) => stdout);
+}

--- a/scripts/tiles-gc/src/r2-object-lister.test.ts
+++ b/scripts/tiles-gc/src/r2-object-lister.test.ts
@@ -18,7 +18,7 @@ function makeListResponse(keys: string[], truncated: boolean, cursor?: string): 
 
 describe('CloudflareApiObjectLister', () => {
   describe('list', () => {
-    it('returns hashed tile filenames from a single page', async () => {
+    it('returns all object keys from a single page', async () => {
       const mockFetch = vi
         .fn<FetchFn>()
         .mockResolvedValue(
@@ -31,9 +31,10 @@ describe('CloudflareApiObjectLister', () => {
       const lister = new CloudflareApiObjectLister(TEST_CREDENTIALS, mockFetch);
       const result = await lister.list(DEV_BUCKET);
 
-      expect(result).toHaveLength(2);
+      expect(result).toHaveLength(3);
       expect(result).toContain('world_1600.fedcba987654.pmtiles');
       expect(result).toContain('world_1700.aabbcc112233.pmtiles');
+      expect(result).toContain('readme.txt');
     });
 
     it('iterates through multiple pages using cursor', async () => {
@@ -51,17 +52,6 @@ describe('CloudflareApiObjectLister', () => {
       expect(mockFetch).toHaveBeenCalledTimes(2);
       const secondCallUrl = mockFetch.mock.calls[1]?.[0] as URL;
       expect(secondCallUrl.searchParams.get('cursor')).toBe('cursor-abc');
-    });
-
-    it('excludes keys that do not match the hashed tile pattern', async () => {
-      const mockFetch = vi
-        .fn<FetchFn>()
-        .mockResolvedValue(makeListResponse(['readme.txt', 'world_1600.pmtiles'], false));
-
-      const lister = new CloudflareApiObjectLister(TEST_CREDENTIALS, mockFetch);
-      const result = await lister.list(DEV_BUCKET);
-
-      expect(result).toHaveLength(0);
     });
 
     it('throws when the API returns a non-ok status', async () => {

--- a/scripts/tiles-gc/src/r2-object-lister.test.ts
+++ b/scripts/tiles-gc/src/r2-object-lister.test.ts
@@ -74,5 +74,25 @@ describe('CloudflareApiObjectLister', () => {
         `Failed to list ${DEV_BUCKET}: 403 Forbidden`,
       );
     });
+
+    it('throws when the response body does not match the expected schema', async () => {
+      const mockFetch = vi
+        .fn<FetchFn>()
+        .mockResolvedValue(new Response(JSON.stringify({}), { status: 200 }));
+
+      const lister = new CloudflareApiObjectLister(TEST_CREDENTIALS, mockFetch);
+      await expect(lister.list(DEV_BUCKET)).rejects.toThrow('Failed to parse R2 list response');
+    });
+
+    it('throws when objects field is not an array', async () => {
+      const mockFetch = vi.fn<FetchFn>().mockResolvedValue(
+        new Response(JSON.stringify({ result: { objects: 'not-an-array', truncated: false } }), {
+          status: 200,
+        }),
+      );
+
+      const lister = new CloudflareApiObjectLister(TEST_CREDENTIALS, mockFetch);
+      await expect(lister.list(DEV_BUCKET)).rejects.toThrow('Failed to parse R2 list response');
+    });
   });
 });

--- a/scripts/tiles-gc/src/r2-object-lister.test.ts
+++ b/scripts/tiles-gc/src/r2-object-lister.test.ts
@@ -1,8 +1,8 @@
 import { describe, expect, it, vi } from 'vitest';
 import { DEV_BUCKET } from './bucket-name.ts';
 import { CloudflareApiCredentials } from './cloudflare-credentials.ts';
-import type { FetchFn } from './r2-bucket.ts';
-import { WranglerR2BucketRepository } from './r2-bucket.ts';
+import type { FetchFn } from './r2-object-lister.ts';
+import { CloudflareApiObjectLister } from './r2-object-lister.ts';
 
 const TEST_CREDENTIALS = CloudflareApiCredentials.fromEnv({
   CLOUDFLARE_ACCOUNT_ID: 'test-account',
@@ -16,8 +16,8 @@ function makeListResponse(keys: string[], truncated: boolean, cursor?: string): 
   );
 }
 
-describe('WranglerR2BucketRepository', () => {
-  describe('listObjects', () => {
+describe('CloudflareApiObjectLister', () => {
+  describe('list', () => {
     it('returns hashed tile filenames from a single page', async () => {
       const mockFetch = vi
         .fn<FetchFn>()
@@ -28,8 +28,8 @@ describe('WranglerR2BucketRepository', () => {
           ),
         );
 
-      const repo = new WranglerR2BucketRepository('/', TEST_CREDENTIALS, undefined, mockFetch);
-      const result = await repo.listObjects(DEV_BUCKET);
+      const lister = new CloudflareApiObjectLister(TEST_CREDENTIALS, mockFetch);
+      const result = await lister.list(DEV_BUCKET);
 
       expect(result).toHaveLength(2);
       expect(result).toContain('world_1600.fedcba987654.pmtiles');
@@ -44,8 +44,8 @@ describe('WranglerR2BucketRepository', () => {
         )
         .mockResolvedValueOnce(makeListResponse(['world_1700.aabbcc112233.pmtiles'], false));
 
-      const repo = new WranglerR2BucketRepository('/', TEST_CREDENTIALS, undefined, mockFetch);
-      const result = await repo.listObjects(DEV_BUCKET);
+      const lister = new CloudflareApiObjectLister(TEST_CREDENTIALS, mockFetch);
+      const result = await lister.list(DEV_BUCKET);
 
       expect(result).toHaveLength(2);
       expect(mockFetch).toHaveBeenCalledTimes(2);
@@ -58,8 +58,8 @@ describe('WranglerR2BucketRepository', () => {
         .fn<FetchFn>()
         .mockResolvedValue(makeListResponse(['readme.txt', 'world_1600.pmtiles'], false));
 
-      const repo = new WranglerR2BucketRepository('/', TEST_CREDENTIALS, undefined, mockFetch);
-      const result = await repo.listObjects(DEV_BUCKET);
+      const lister = new CloudflareApiObjectLister(TEST_CREDENTIALS, mockFetch);
+      const result = await lister.list(DEV_BUCKET);
 
       expect(result).toHaveLength(0);
     });
@@ -69,8 +69,8 @@ describe('WranglerR2BucketRepository', () => {
         .fn<FetchFn>()
         .mockResolvedValue(new Response(null, { status: 403, statusText: 'Forbidden' }));
 
-      const repo = new WranglerR2BucketRepository('/', TEST_CREDENTIALS, undefined, mockFetch);
-      await expect(repo.listObjects(DEV_BUCKET)).rejects.toThrow(
+      const lister = new CloudflareApiObjectLister(TEST_CREDENTIALS, mockFetch);
+      await expect(lister.list(DEV_BUCKET)).rejects.toThrow(
         `Failed to list ${DEV_BUCKET}: 403 Forbidden`,
       );
     });

--- a/scripts/tiles-gc/src/r2-object-lister.ts
+++ b/scripts/tiles-gc/src/r2-object-lister.ts
@@ -1,4 +1,5 @@
 import { type HashedFilename, HashedTileFilename } from '@world-history-map/tiles';
+import { z } from 'zod';
 import type { BucketName } from './bucket-name.ts';
 import type { CloudflareApiCredentials } from './cloudflare-credentials.ts';
 
@@ -6,17 +7,13 @@ const CLOUDFLARE_API_BASE_URL = 'https://api.cloudflare.com/client/v4';
 
 export type FetchFn = typeof fetch;
 
-interface CloudflareR2Object {
-  readonly key: string;
-}
-
-interface CloudflareR2ListResult {
-  readonly result: {
-    readonly objects: readonly CloudflareR2Object[];
-    readonly truncated: boolean;
-    readonly cursor?: string;
-  };
-}
+const CloudflareR2ListResultSchema = z.object({
+  result: z.object({
+    objects: z.array(z.object({ key: z.string() })),
+    truncated: z.boolean(),
+    cursor: z.string().optional(),
+  }),
+});
 
 export interface R2ObjectLister {
   list(bucket: BucketName): Promise<readonly HashedFilename[]>;
@@ -66,10 +63,13 @@ export class CloudflareApiObjectLister implements R2ObjectLister {
       throw new Error(`Failed to list ${bucket}: ${response.status} ${response.statusText}`);
     }
 
-    const listResponse = (await response.json()) as CloudflareR2ListResult;
+    const parsed = CloudflareR2ListResultSchema.safeParse(await response.json());
+    if (!parsed.success) {
+      throw new Error(`Failed to parse R2 list response: ${parsed.error.message}`);
+    }
     return {
-      keys: listResponse.result.objects.map((r2Object) => r2Object.key),
-      nextCursor: listResponse.result.truncated ? listResponse.result.cursor : undefined,
+      keys: parsed.data.result.objects.map((r2Object) => r2Object.key),
+      nextCursor: parsed.data.result.truncated ? parsed.data.result.cursor : undefined,
     };
   }
 }

--- a/scripts/tiles-gc/src/r2-object-lister.ts
+++ b/scripts/tiles-gc/src/r2-object-lister.ts
@@ -30,18 +30,19 @@ export class CloudflareApiObjectLister implements R2ObjectLister {
 
   async list(bucket: BucketName): Promise<readonly HashedFilename[]> {
     const objectKeys = await this.#fetchAllObjectKeys(bucket);
-    return HashedTileFilename.parseAll(objectKeys).map((tile) => tile.toString() as HashedFilename);
+    return HashedTileFilename.parseAll(objectKeys).map((tile) => tile.toString());
   }
 
   async #fetchAllObjectKeys(bucket: BucketName): Promise<readonly string[]> {
     const objectKeys: string[] = [];
-    let nextPageCursor: string | undefined;
+    let cursor: string | undefined;
 
-    do {
-      const page = await this.#fetchObjectsPage(bucket, nextPageCursor);
+    while (true) {
+      const page = await this.#fetchObjectsPage(bucket, cursor);
       objectKeys.push(...page.keys);
-      nextPageCursor = page.nextCursor;
-    } while (nextPageCursor !== undefined);
+      if (page.nextCursor === undefined) break;
+      cursor = page.nextCursor;
+    }
 
     return objectKeys;
   }

--- a/scripts/tiles-gc/src/r2-object-lister.ts
+++ b/scripts/tiles-gc/src/r2-object-lister.ts
@@ -1,14 +1,8 @@
-import { execFile } from 'node:child_process';
-import { promisify } from 'node:util';
 import { type HashedFilename, HashedTileFilename } from '@world-history-map/tiles';
 import type { BucketName } from './bucket-name.ts';
 import type { CloudflareApiCredentials } from './cloudflare-credentials.ts';
 
-const execFileAsync = promisify(execFile);
-
 const CLOUDFLARE_API_BASE_URL = 'https://api.cloudflare.com/client/v4';
-
-export type ExecWrangler = (args: readonly string[], cwd: string) => Promise<string>;
 
 export type FetchFn = typeof fetch;
 
@@ -24,30 +18,20 @@ interface CloudflareR2ListResult {
   };
 }
 
-export interface R2BucketRepository {
-  listObjects(bucket: BucketName): Promise<readonly HashedFilename[]>;
-  deleteObject(bucket: BucketName, key: HashedFilename): Promise<void>;
+export interface R2ObjectLister {
+  list(bucket: BucketName): Promise<readonly HashedFilename[]>;
 }
 
-export class WranglerR2BucketRepository implements R2BucketRepository {
-  readonly #repoRoot: string;
+export class CloudflareApiObjectLister implements R2ObjectLister {
   readonly #credentials: CloudflareApiCredentials;
-  readonly #execWrangler: ExecWrangler;
   readonly #fetchFn: FetchFn;
 
-  constructor(
-    repoRoot: string,
-    credentials: CloudflareApiCredentials,
-    execWrangler?: ExecWrangler,
-    fetchFn?: FetchFn,
-  ) {
-    this.#repoRoot = repoRoot;
+  constructor(credentials: CloudflareApiCredentials, fetchFn?: FetchFn) {
     this.#credentials = credentials;
-    this.#execWrangler = execWrangler ?? defaultExecWrangler;
     this.#fetchFn = fetchFn ?? defaultFetch;
   }
 
-  async listObjects(bucket: BucketName): Promise<readonly HashedFilename[]> {
+  async list(bucket: BucketName): Promise<readonly HashedFilename[]> {
     const objectKeys = await this.#fetchAllObjectKeys(bucket);
     return HashedTileFilename.parseAll(objectKeys).map((tile) => tile.toString() as HashedFilename);
   }
@@ -88,17 +72,6 @@ export class WranglerR2BucketRepository implements R2BucketRepository {
       nextCursor: listResponse.result.truncated ? listResponse.result.cursor : undefined,
     };
   }
-
-  async deleteObject(bucket: BucketName, key: HashedFilename): Promise<void> {
-    await this.#execWrangler(
-      ['r2', 'object', 'delete', `${bucket}/${key}`, '--remote'],
-      this.#repoRoot,
-    );
-  }
-}
-
-function defaultExecWrangler(args: readonly string[], cwd: string): Promise<string> {
-  return execFileAsync('wrangler', [...args], { cwd }).then(({ stdout }) => stdout);
 }
 
 function defaultFetch(...args: Parameters<FetchFn>): ReturnType<FetchFn> {

--- a/scripts/tiles-gc/src/r2-object-lister.ts
+++ b/scripts/tiles-gc/src/r2-object-lister.ts
@@ -1,4 +1,3 @@
-import { type HashedFilename, HashedTileFilename } from '@world-history-map/tiles';
 import { z } from 'zod';
 import type { BucketName } from './bucket-name.ts';
 import type { CloudflareApiCredentials } from './cloudflare-credentials.ts';
@@ -19,7 +18,7 @@ const CloudflareR2ListResultSchema = z
   }));
 
 export interface R2ObjectLister {
-  list(bucket: BucketName): Promise<readonly HashedFilename[]>;
+  list(bucket: BucketName): Promise<readonly string[]>;
 }
 
 export class CloudflareApiObjectLister implements R2ObjectLister {
@@ -31,9 +30,8 @@ export class CloudflareApiObjectLister implements R2ObjectLister {
     this.#fetchFn = fetchFn ?? defaultFetch;
   }
 
-  async list(bucket: BucketName): Promise<readonly HashedFilename[]> {
-    const objectKeys = await this.#fetchAllObjectKeys(bucket);
-    return HashedTileFilename.parseAll(objectKeys).map((tile) => tile.toString());
+  async list(bucket: BucketName): Promise<readonly string[]> {
+    return this.#fetchAllObjectKeys(bucket);
   }
 
   async #fetchAllObjectKeys(bucket: BucketName): Promise<readonly string[]> {

--- a/scripts/tiles-gc/src/r2-object-lister.ts
+++ b/scripts/tiles-gc/src/r2-object-lister.ts
@@ -3,8 +3,6 @@ import { z } from 'zod';
 import type { BucketName } from './bucket-name.ts';
 import type { CloudflareApiCredentials } from './cloudflare-credentials.ts';
 
-const CLOUDFLARE_API_BASE_URL = 'https://api.cloudflare.com/client/v4';
-
 export type FetchFn = typeof fetch;
 
 const CloudflareR2ListResultSchema = z
@@ -56,11 +54,7 @@ export class CloudflareApiObjectLister implements R2ObjectLister {
     bucket: BucketName,
     cursor: string | undefined,
   ): Promise<{ readonly keys: readonly string[]; readonly nextCursor: string | undefined }> {
-    const url = new URL(
-      `${CLOUDFLARE_API_BASE_URL}/accounts/${this.#credentials.accountId}/r2/buckets/${bucket}/objects`,
-    );
-    if (cursor !== undefined) url.searchParams.set('cursor', cursor);
-
+    const url = this.#credentials.r2ListUrl(bucket, cursor);
     const response = await this.#fetchFn(url, { headers: this.#credentials.authHeader() });
     ensureOk(response, bucket);
     return parseListResult(await response.json());

--- a/scripts/tiles-gc/src/r2-object-lister.ts
+++ b/scripts/tiles-gc/src/r2-object-lister.ts
@@ -7,13 +7,18 @@ const CLOUDFLARE_API_BASE_URL = 'https://api.cloudflare.com/client/v4';
 
 export type FetchFn = typeof fetch;
 
-const CloudflareR2ListResultSchema = z.object({
-  result: z.object({
-    objects: z.array(z.object({ key: z.string() })),
-    truncated: z.boolean(),
-    cursor: z.string().optional(),
-  }),
-});
+const CloudflareR2ListResultSchema = z
+  .object({
+    result: z.object({
+      objects: z.array(z.object({ key: z.string() })),
+      truncated: z.boolean(),
+      cursor: z.string().optional(),
+    }),
+  })
+  .transform((data) => ({
+    keys: data.result.objects.map((o) => o.key),
+    nextCursor: data.result.truncated ? data.result.cursor : undefined,
+  }));
 
 export interface R2ObjectLister {
   list(bucket: BucketName): Promise<readonly HashedFilename[]>;
@@ -56,23 +61,27 @@ export class CloudflareApiObjectLister implements R2ObjectLister {
     );
     if (cursor !== undefined) url.searchParams.set('cursor', cursor);
 
-    const response = await this.#fetchFn(url, {
-      headers: this.#credentials.authHeader(),
-    });
-
-    if (!response.ok) {
-      throw new Error(`Failed to list ${bucket}: ${response.status} ${response.statusText}`);
-    }
-
-    const parsed = CloudflareR2ListResultSchema.safeParse(await response.json());
-    if (!parsed.success) {
-      throw new Error(`Failed to parse R2 list response: ${parsed.error.message}`);
-    }
-    return {
-      keys: parsed.data.result.objects.map((r2Object) => r2Object.key),
-      nextCursor: parsed.data.result.truncated ? parsed.data.result.cursor : undefined,
-    };
+    const response = await this.#fetchFn(url, { headers: this.#credentials.authHeader() });
+    ensureOk(response, bucket);
+    return parseListResult(await response.json());
   }
+}
+
+function ensureOk(response: Response, bucket: BucketName): void {
+  if (!response.ok) {
+    throw new Error(`Failed to list ${bucket}: ${response.status} ${response.statusText}`);
+  }
+}
+
+function parseListResult(json: unknown): {
+  readonly keys: readonly string[];
+  readonly nextCursor: string | undefined;
+} {
+  const parsed = CloudflareR2ListResultSchema.safeParse(json);
+  if (!parsed.success) {
+    throw new Error(`Failed to parse R2 list response: ${parsed.error.message}`);
+  }
+  return parsed.data;
 }
 
 function defaultFetch(...args: Parameters<FetchFn>): ReturnType<FetchFn> {

--- a/scripts/tiles-gc/src/retained-hashes.ts
+++ b/scripts/tiles-gc/src/retained-hashes.ts
@@ -1,0 +1,34 @@
+import type { HashedFilename, TilesManifest } from '@world-history-map/tiles';
+import { DeletionPlan } from './deletion-plan.ts';
+
+export class RetainedHashes {
+  readonly #hashes: ReadonlySet<HashedFilename>;
+
+  private constructor(hashes: ReadonlySet<HashedFilename>) {
+    this.#hashes = hashes;
+  }
+
+  static fromSnapshots(snapshots: readonly TilesManifest[]): RetainedHashes {
+    const hashes = new Set<HashedFilename>();
+    for (const manifest of snapshots) {
+      for (const year of manifest.availableYears()) {
+        const filename = manifest.filenameFor(year);
+        if (filename) hashes.add(filename);
+      }
+    }
+    return new RetainedHashes(hashes);
+  }
+
+  get size(): number {
+    return this.#hashes.size;
+  }
+
+  has(hash: HashedFilename): boolean {
+    return this.#hashes.has(hash);
+  }
+
+  difference(candidates: readonly HashedFilename[]): DeletionPlan {
+    const orphans = candidates.filter((key) => !this.#hashes.has(key));
+    return DeletionPlan.fromCandidates(orphans);
+  }
+}


### PR DESCRIPTION
## 概要

PR #221（fix(tiles-gc): replace wrangler r2 object list with Cloudflare REST API）の追加コミットで残した設計改善 C1・Mn1 を実施します。

### C1: R2 リポジトリの interface 分離

`R2BucketRepository`（list と delete を同居）を 2 つの focused な interface に分割しました。

| 旧 | 新 |
|----|-----|
| `R2BucketRepository.listObjects()` | `R2ObjectLister.list()` / `CloudflareApiObjectLister` |
| `R2BucketRepository.deleteObject()` | `R2ObjectDeleter.delete()` / `WranglerObjectDeleter` |

- `GcUseCase` は `R2ObjectLister` のみに依存（ISP 遵守）
- `LiveGcExecution` は `R2ObjectDeleter` のみに依存（ISP 遵守）
- テストモックが各クラスで必要な interface のみになり簡潔に

### Mn1: zod によるレスポンス検証

Cloudflare API レスポンスの `as CloudflareR2ListResult` 無検証キャストを zod の `safeParse` に置き換えました。API の仕様変更時に明瞭なエラーが即座に発生します。

## 変更内容

- **新規**: `scripts/tiles-gc/src/r2-object-lister.ts` / `r2-object-lister.test.ts`
- **新規**: `scripts/tiles-gc/src/r2-object-deleter.ts` / `r2-object-deleter.test.ts`
- **削除**: `scripts/tiles-gc/src/r2-bucket.ts` / `r2-bucket.test.ts`
- **修正**: `gc-use-case.ts`, `gc-execution.ts`, `gc.test.ts`, `cli.ts`
- **修正**: `package.json`（zod 追加）

## 動作確認

- [ ] `gh workflow run tiles-gc.yml -f dry_run=true -f window_size=3 -f target_env=both` でエラーなく保持集合・削除候補が表示される

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)