### PR TITLE
fix(tiles-gc): fix R2 list response schema to match actual API format

### DIFF
--- a/scripts/tiles-gc/src/r2-object-lister.test.ts
+++ b/scripts/tiles-gc/src/r2-object-lister.test.ts
@@ -11,7 +11,7 @@ const TEST_CREDENTIALS = CloudflareApiCredentials.fromEnv({
 
 function makeListResponse(keys: string[], truncated: boolean, cursor?: string): Response {
   return new Response(
-    JSON.stringify({ result: { objects: keys.map((key) => ({ key })), truncated, cursor } }),
+    JSON.stringify({ objects: keys.map((key) => ({ key })), truncated, cursor }),
     { status: 200 },
   );
 }
@@ -76,7 +76,7 @@ describe('CloudflareApiObjectLister', () => {
 
     it('throws when objects field is not an array', async () => {
       const mockFetch = vi.fn<FetchFn>().mockResolvedValue(
-        new Response(JSON.stringify({ result: { objects: 'not-an-array', truncated: false } }), {
+        new Response(JSON.stringify({ objects: 'not-an-array', truncated: false }), {
           status: 200,
         }),
       );

--- a/scripts/tiles-gc/src/r2-object-lister.ts
+++ b/scripts/tiles-gc/src/r2-object-lister.ts
@@ -6,15 +6,13 @@ export type FetchFn = typeof fetch;
 
 const CloudflareR2ListResultSchema = z
   .object({
-    result: z.object({
-      objects: z.array(z.object({ key: z.string() })),
-      truncated: z.boolean(),
-      cursor: z.string().optional(),
-    }),
+    objects: z.array(z.object({ key: z.string() })),
+    truncated: z.boolean(),
+    cursor: z.string().optional(),
   })
   .transform((data) => ({
-    keys: data.result.objects.map((o) => o.key),
-    nextCursor: data.result.truncated ? data.result.cursor : undefined,
+    keys: data.objects.map((o) => o.key),
+    nextCursor: data.truncated ? data.cursor : undefined,
   }));
 
 export interface R2ObjectLister {


### PR DESCRIPTION
## 概要

T054（GC dry-run）実行時に発生していたレスポンスパースエラーを修正します。

### 背景

Cloudflare R2 API のオブジェクト一覧エンドポイントが返すレスポンス形式を誤って実装していました。

- **誤り**: `{ result: { objects: [...], truncated: bool } }` — Cloudflare v4 標準ラッパー形式を仮定
- **正しい**: `{ objects: [...], truncated: bool, cursor: '...' }` — R2 API は flat 形式で返す

公式ドキュメント（[Cloudflare R2 LIST Objects](https://developers.cloudflare.com/workers/llms-full.txt)）に従い修正しました。

### 変更内容

- `src/r2-object-lister.ts`: Zod スキーマを flat 形式に修正
- `src/r2-object-lister.test.ts`: テストフィクスチャを flat 形式に修正

## 動作確認

- [ ] `gh workflow run tiles-gc.yml -f dry_run=true -f window_size=3 -f target_env=both` でエラーなく保持集合・削除候補が表示される

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
