### PR TITLE
fix(tiles-gc): correct R2 list schema — result is a flat array

### DIFF
--- a/scripts/tiles-gc/src/r2-object-lister.test.ts
+++ b/scripts/tiles-gc/src/r2-object-lister.test.ts
@@ -9,23 +9,29 @@ const TEST_CREDENTIALS = CloudflareApiCredentials.fromEnv({
   CLOUDFLARE_API_TOKEN: 'test-token',
 });
 
-function makeListResponse(keys: string[], truncated: boolean, cursor?: string): Response {
+function makeListResponse(keys: string[]): Response {
   return new Response(
-    JSON.stringify({ result: { objects: keys.map((key) => ({ key })), truncated, cursor } }),
+    JSON.stringify({
+      success: true,
+      errors: [],
+      messages: [],
+      result: keys.map((key) => ({ key })),
+    }),
     { status: 200 },
   );
 }
 
 describe('CloudflareApiObjectLister', () => {
   describe('list', () => {
-    it('returns all object keys from a single page', async () => {
+    it('returns all object keys from the response', async () => {
       const mockFetch = vi
         .fn<FetchFn>()
         .mockResolvedValue(
-          makeListResponse(
-            ['world_1600.fedcba987654.pmtiles', 'world_1700.aabbcc112233.pmtiles', 'readme.txt'],
-            false,
-          ),
+          makeListResponse([
+            'world_1600.fedcba987654.pmtiles',
+            'world_1700.aabbcc112233.pmtiles',
+            'readme.txt',
+          ]),
         );
 
       const lister = new CloudflareApiObjectLister(TEST_CREDENTIALS, mockFetch);
@@ -37,21 +43,13 @@ describe('CloudflareApiObjectLister', () => {
       expect(result).toContain('readme.txt');
     });
 
-    it('iterates through multiple pages using cursor', async () => {
-      const mockFetch = vi
-        .fn<FetchFn>()
-        .mockResolvedValueOnce(
-          makeListResponse(['world_1600.fedcba987654.pmtiles'], true, 'cursor-abc'),
-        )
-        .mockResolvedValueOnce(makeListResponse(['world_1700.aabbcc112233.pmtiles'], false));
+    it('returns an empty list when the bucket is empty', async () => {
+      const mockFetch = vi.fn<FetchFn>().mockResolvedValue(makeListResponse([]));
 
       const lister = new CloudflareApiObjectLister(TEST_CREDENTIALS, mockFetch);
       const result = await lister.list(DEV_BUCKET);
 
-      expect(result).toHaveLength(2);
-      expect(mockFetch).toHaveBeenCalledTimes(2);
-      const secondCallUrl = mockFetch.mock.calls[1]?.[0] as URL;
-      expect(secondCallUrl.searchParams.get('cursor')).toBe('cursor-abc');
+      expect(result).toHaveLength(0);
     });
 
     it('throws when the API returns a non-ok status', async () => {
@@ -74,9 +72,9 @@ describe('CloudflareApiObjectLister', () => {
       await expect(lister.list(DEV_BUCKET)).rejects.toThrow('Failed to parse R2 list response');
     });
 
-    it('throws when objects field is not an array', async () => {
+    it('throws when result field is not an array', async () => {
       const mockFetch = vi.fn<FetchFn>().mockResolvedValue(
-        new Response(JSON.stringify({ result: { objects: 'not-an-array', truncated: false } }), {
+        new Response(JSON.stringify({ success: true, errors: [], result: 'not-an-array' }), {
           status: 200,
         }),
       );

--- a/scripts/tiles-gc/src/r2-object-lister.ts
+++ b/scripts/tiles-gc/src/r2-object-lister.ts
@@ -6,15 +6,11 @@ export type FetchFn = typeof fetch;
 
 const CloudflareR2ListResultSchema = z
   .object({
-    result: z.object({
-      objects: z.array(z.object({ key: z.string() })),
-      truncated: z.boolean(),
-      cursor: z.string().optional(),
-    }),
+    result: z.array(z.object({ key: z.string() })),
   })
   .transform((data) => ({
-    keys: data.result.objects.map((o) => o.key),
-    nextCursor: data.result.truncated ? data.result.cursor : undefined,
+    keys: data.result.map((o) => o.key),
+    nextCursor: undefined as string | undefined,
   }));
 
 export interface R2ObjectLister {
@@ -69,7 +65,6 @@ function parseListResult(json: unknown): {
   readonly keys: readonly string[];
   readonly nextCursor: string | undefined;
 } {
-  console.log('R2 API raw response:', JSON.stringify(json, null, 2));
   const parsed = CloudflareR2ListResultSchema.safeParse(json);
   if (!parsed.success) {
     throw new Error(`Failed to parse R2 list response: ${parsed.error.message}`);

--- a/scripts/tiles-gc/src/r2-object-lister.ts
+++ b/scripts/tiles-gc/src/r2-object-lister.ts
@@ -69,6 +69,7 @@ function parseListResult(json: unknown): {
   readonly keys: readonly string[];
   readonly nextCursor: string | undefined;
 } {
+  console.log('R2 API raw response:', JSON.stringify(json, null, 2));
   const parsed = CloudflareR2ListResultSchema.safeParse(json);
   if (!parsed.success) {
     throw new Error(`Failed to parse R2 list response: ${parsed.error.message}`);


### PR DESCRIPTION
## 概要

GC workflow の R2 API レスポンス形式を実際の API 出力に合わせて修正します。

### 背景

CI ログから実際のレスポンスを確認したところ、Cloudflare R2 list API は次の形式でした：

```json
{
  "success": true,
  "errors": [],
  "result": [ { "key": "world_1600.abc.pmtiles", ... }, ... ]
}
```

`result` が **配列**（nested object でも flat でもない）。誤ったドキュメントを参照していたため 3 回のスキーマ修正が必要でした。

### 変更内容

- `src/r2-object-lister.ts`: Zod スキーマを `{ result: array }` 形式に修正、不要なページネーション処理を削除
- `src/r2-object-lister.test.ts`: テストフィクスチャを実際の API 形式に合わせて更新

### 動作確認済み

`gh workflow run tiles-gc.yml --ref debug/tiles-gc-r2-response -f dry_run=true -f window_size=3 -f target_env=both` で正常完了を確認：
- Retained hashes: 106
- Candidates: 0（dev / prod 両バケット）

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
