### PR TITLE
revert: T045 — restore world_1600 tile to previous hash

### DIFF
--- a/packages/tiles/src/manifest.ts
+++ b/packages/tiles/src/manifest.ts
@@ -34,7 +34,7 @@ export const manifest = {
   '1492': 'world_1492.ecf75d3737a1.pmtiles',
   '1500': 'world_1500.81f1f33ddd83.pmtiles',
   '1530': 'world_1530.b1149259e74c.pmtiles',
-  '1600': 'world_1600.9079a57bc414.pmtiles',
+  '1600': 'world_1600.be885444b112.pmtiles',
   '1650': 'world_1650.6f1edc435fbf.pmtiles',
   '1700': 'world_1700.68ff75ee70dd.pmtiles',
   '1715': 'world_1715.7d84f40dbb4a.pmtiles',


### PR DESCRIPTION
T045 ロールバック検証用 revert PR。

## 変更内容

`9f5a492` を revert し、manifest.ts のハッシュを元に戻します:

- 新ハッシュ（現在の本番）: `world_1600.9079a57bc414.pmtiles`
- 旧ハッシュ（revert 後）: `world_1600.be885444b112.pmtiles`

## 確認すること

マージ後 5 分以内に:
- DevTools Network タブで `world_1600.be885444b112.pmtiles` が取得される
- 404 が出ない（旧ハッシュファイルが R2 に残っている）

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)