### PR TITLE
feat(ui): introduce role-based color tokens and redesign event timeline

### DIFF
--- a/apps/frontend/src/components/feedback/role-error-message.tsx
+++ b/apps/frontend/src/components/feedback/role-error-message.tsx
@@ -1,0 +1,3 @@
+export function RoleErrorMessage({ children }: { children: React.ReactNode }) {
+  return <p className="m-3 rounded p-3 bg-role-error/10 text-role-error">{children}</p>;
+}

--- a/apps/frontend/src/components/feedback/role-spinner.tsx
+++ b/apps/frontend/src/components/feedback/role-spinner.tsx
@@ -1,0 +1,7 @@
+export function RoleSpinner() {
+  return (
+    <div className="flex items-center justify-center py-8">
+      <div className="h-8 w-8 animate-spin rounded-full border-4 border-role-loading border-t-transparent" />
+    </div>
+  );
+}

--- a/apps/frontend/src/components/map/map-view.tsx
+++ b/apps/frontend/src/components/map/map-view.tsx
@@ -110,7 +110,7 @@ export function MapView() {
           <div className="flex flex-col items-center">
             <div className="relative h-16 w-16">
               <svg
-                className="h-16 w-16 animate-spin text-role-state"
+                className="h-16 w-16 animate-spin text-role-loading"
                 style={{ animationDuration: LOADING_SPIN_DURATION }}
                 viewBox="0 0 24 24"
                 fill="none"

--- a/apps/frontend/src/components/map/map-view.tsx
+++ b/apps/frontend/src/components/map/map-view.tsx
@@ -84,8 +84,8 @@ export function MapView() {
         data-testid="map-error"
       >
         <div className="text-center">
-          <p className="text-lg text-red-400">Failed to load map data</p>
-          <p className="text-sm text-red-300">{error}</p>
+          <p className="text-lg text-role-error">Failed to load map data</p>
+          <p className="text-sm text-role-error/80">{error}</p>
         </div>
       </div>
     );
@@ -110,7 +110,7 @@ export function MapView() {
           <div className="flex flex-col items-center">
             <div className="relative h-16 w-16">
               <svg
-                className="h-16 w-16 animate-spin text-blue-400"
+                className="h-16 w-16 animate-spin text-role-state"
                 style={{ animationDuration: LOADING_SPIN_DURATION }}
                 viewBox="0 0 24 24"
                 fill="none"

--- a/apps/frontend/src/components/map/territory-highlight-layer.test.tsx
+++ b/apps/frontend/src/components/map/territory-highlight-layer.test.tsx
@@ -2,6 +2,11 @@ import { render, screen } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
 import { TerritoryHighlightLayer } from './territory-highlight-layer';
 import { TERRITORY_LABEL_ID } from './territory-label';
+import {
+  HIGHLIGHT_COLOR,
+  HIGHLIGHT_FILL_OPACITY,
+  HIGHLIGHT_LINE_WIDTH,
+} from './territory-style-constants';
 
 vi.mock('react-map-gl/maplibre', () => ({
   Layer: vi.fn((props) => (
@@ -59,8 +64,8 @@ describe('TerritoryHighlightLayer', () => {
     const paint = JSON.parse(fillLayer.getAttribute('data-paint') ?? '');
 
     expect(paint).toEqual({
-      'fill-color': '#f43f5e',
-      'fill-opacity': 0.2,
+      'fill-color': HIGHLIGHT_COLOR,
+      'fill-opacity': HIGHLIGHT_FILL_OPACITY,
     });
   });
 
@@ -71,8 +76,8 @@ describe('TerritoryHighlightLayer', () => {
     const paint = JSON.parse(outlineLayer.getAttribute('data-paint') ?? '');
 
     expect(paint).toEqual({
-      'line-color': '#f43f5e',
-      'line-width': 3.5,
+      'line-color': HIGHLIGHT_COLOR,
+      'line-width': HIGHLIGHT_LINE_WIDTH,
     });
   });
 

--- a/apps/frontend/src/components/map/territory-highlight-layer.test.tsx
+++ b/apps/frontend/src/components/map/territory-highlight-layer.test.tsx
@@ -59,8 +59,8 @@ describe('TerritoryHighlightLayer', () => {
     const paint = JSON.parse(fillLayer.getAttribute('data-paint') ?? '');
 
     expect(paint).toEqual({
-      'fill-color': '#ffffff',
-      'fill-opacity': 0.15,
+      'fill-color': '#f43f5e',
+      'fill-opacity': 0.2,
     });
   });
 
@@ -71,7 +71,7 @@ describe('TerritoryHighlightLayer', () => {
     const paint = JSON.parse(outlineLayer.getAttribute('data-paint') ?? '');
 
     expect(paint).toEqual({
-      'line-color': '#ffffff',
+      'line-color': '#f43f5e',
       'line-width': 3.5,
     });
   });

--- a/apps/frontend/src/components/map/territory-style-constants.ts
+++ b/apps/frontend/src/components/map/territory-style-constants.ts
@@ -44,8 +44,10 @@ export const LABEL_ANCHOR: ('center' | 'top' | 'bottom' | 'left' | 'right')[] = 
 
 export const TERRITORY_FILL_OPACITY = 0.7;
 
-export const HIGHLIGHT_COLOR = '#ffffff';
-export const HIGHLIGHT_FILL_OPACITY = 0.15;
+// Mirrors --color-role-selected from index.css.
+// MapLibre paint props cannot reference CSS variables.
+export const HIGHLIGHT_COLOR = '#f43f5e';
+export const HIGHLIGHT_FILL_OPACITY = 0.2;
 export const HIGHLIGHT_LINE_WIDTH = 3.5;
 
 export const LOADING_SPIN_DURATION = '3s';

--- a/apps/frontend/src/components/territory-info/selected-accent.tsx
+++ b/apps/frontend/src/components/territory-info/selected-accent.tsx
@@ -1,0 +1,13 @@
+import { cn } from '@/lib/utils';
+
+export const SELECTED_ACCENT_CLASS = 'border-l-4 border-role-selected';
+
+export function SelectedAccent({
+  children,
+  className,
+}: {
+  children: React.ReactNode;
+  className?: string;
+}) {
+  return <div className={cn(SELECTED_ACCENT_CLASS, className)}>{children}</div>;
+}

--- a/apps/frontend/src/components/territory-info/territory-info-panel.tsx
+++ b/apps/frontend/src/components/territory-info/territory-info-panel.tsx
@@ -65,7 +65,7 @@ function PanelHeader({
 function LoadingBody() {
   return (
     <div className="flex items-center justify-center py-8">
-      <div className="h-8 w-8 animate-spin rounded-full border-4 border-role-state border-t-transparent" />
+      <div className="h-8 w-8 animate-spin rounded-full border-4 border-role-loading border-t-transparent" />
     </div>
   );
 }

--- a/apps/frontend/src/components/territory-info/territory-info-panel.tsx
+++ b/apps/frontend/src/components/territory-info/territory-info-panel.tsx
@@ -65,13 +65,13 @@ function PanelHeader({
 function LoadingBody() {
   return (
     <div className="flex items-center justify-center py-8">
-      <div className="h-8 w-8 animate-spin rounded-full border-4 border-blue-400 border-t-transparent" />
+      <div className="h-8 w-8 animate-spin rounded-full border-4 border-role-state border-t-transparent" />
     </div>
   );
 }
 
 function ErrorBody({ error }: { error: string | null }) {
-  return <p className="p-4 text-red-400">{error}</p>;
+  return <p className="m-3 rounded p-3 bg-role-error/10 text-role-error">{error}</p>;
 }
 
 function NoDescriptionBody() {

--- a/apps/frontend/src/components/territory-info/territory-info-panel.tsx
+++ b/apps/frontend/src/components/territory-info/territory-info-panel.tsx
@@ -14,6 +14,29 @@ import { SELECTED_ACCENT_CLASS, SelectedAccent } from './selected-accent';
 import { TerritoryProfile } from './territory-profile';
 import { TerritoryTimeline } from './territory-timeline';
 
+type PanelState =
+  | { kind: 'loading'; name: string }
+  | { kind: 'error'; message: string }
+  | { kind: 'empty'; name: string }
+  | { kind: 'loaded'; description: TerritoryDescription };
+
+interface ContentProps {
+  description: TerritoryDescription | null;
+  isLoading: boolean;
+  error: string | null;
+  selectedTerritory: string | null;
+  selectedYear: HistoricalYear;
+  onClose: () => void;
+}
+
+function panelState(props: ContentProps): PanelState {
+  const { description, isLoading, error, selectedTerritory } = props;
+  if (isLoading) return { kind: 'loading', name: selectedTerritory ?? '読み込み中…' };
+  if (error) return { kind: 'error', message: error };
+  if (!description) return { kind: 'empty', name: selectedTerritory ?? '領土情報' };
+  return { kind: 'loaded', description };
+}
+
 function PanelWrapper({
   children,
   scrollable,
@@ -92,71 +115,56 @@ function DescriptionBody({
   );
 }
 
-interface ContentProps {
-  description: TerritoryDescription | null;
-  isLoading: boolean;
-  error: string | null;
-  selectedTerritory: string | null;
-  selectedYear: HistoricalYear;
-  onClose: () => void;
+function DesktopContent(props: ContentProps) {
+  const { onClose, selectedYear } = props;
+  const state = panelState(props);
+
+  switch (state.kind) {
+    case 'loading':
+      return (
+        <PanelWrapper busy>
+          <PanelHeader name={state.name} onClose={onClose} />
+          <RoleSpinner />
+        </PanelWrapper>
+      );
+    case 'error':
+      return (
+        <PanelWrapper>
+          <PanelHeader name="エラー" onClose={onClose} />
+          <RoleErrorMessage>{state.message}</RoleErrorMessage>
+        </PanelWrapper>
+      );
+    case 'empty':
+      return (
+        <PanelWrapper>
+          <PanelHeader name={state.name} onClose={onClose} />
+          <NoDescriptionBody />
+        </PanelWrapper>
+      );
+    case 'loaded':
+      return (
+        <PanelWrapper scrollable>
+          <PanelHeader
+            name={state.description.name}
+            era={state.description.era}
+            onClose={onClose}
+          />
+          <DescriptionBody description={state.description} selectedYear={selectedYear} />
+        </PanelWrapper>
+      );
+  }
 }
 
-function DesktopContent({
-  description,
-  isLoading,
-  error,
-  selectedTerritory,
-  selectedYear,
-  onClose,
-}: ContentProps) {
-  if (isLoading) {
-    return (
-      <PanelWrapper busy>
-        <PanelHeader name={selectedTerritory ?? '読み込み中…'} onClose={onClose} />
-        <RoleSpinner />
-      </PanelWrapper>
-    );
-  }
-  if (error) {
-    return (
-      <PanelWrapper>
-        <PanelHeader name="エラー" onClose={onClose} />
-        <RoleErrorMessage>{error}</RoleErrorMessage>
-      </PanelWrapper>
-    );
-  }
-  if (!description) {
-    return (
-      <PanelWrapper>
-        <PanelHeader name={selectedTerritory ?? '領土情報'} onClose={onClose} />
-        <NoDescriptionBody />
-      </PanelWrapper>
-    );
-  }
-  return (
-    <PanelWrapper scrollable>
-      <PanelHeader name={description.name} era={description.era} onClose={onClose} />
-      <DescriptionBody description={description} selectedYear={selectedYear} />
-    </PanelWrapper>
-  );
-}
-
-function MobileContent({
-  description,
-  isLoading,
-  error,
-  selectedTerritory,
-  selectedYear,
-  onClose,
-}: ContentProps) {
-  const headerName = isLoading
-    ? (selectedTerritory ?? '読み込み中…')
-    : error
-      ? 'エラー'
-      : description
-        ? description.name
-        : (selectedTerritory ?? '領土情報');
-  const headerEra = description && !isLoading && !error ? description.era : undefined;
+function MobileContent(props: ContentProps) {
+  const { onClose, selectedYear } = props;
+  const state = panelState(props);
+  const headerName =
+    state.kind === 'loaded'
+      ? state.description.name
+      : state.kind === 'error'
+        ? 'エラー'
+        : state.name;
+  const headerEra = state.kind === 'loaded' ? state.description.era : undefined;
 
   return (
     <BottomSheet
@@ -169,14 +177,14 @@ function MobileContent({
       }
       aria-labelledby="territory-info-title"
     >
-      {isLoading ? (
+      {state.kind === 'loading' ? (
         <RoleSpinner />
-      ) : error ? (
-        <RoleErrorMessage>{error}</RoleErrorMessage>
-      ) : !description ? (
+      ) : state.kind === 'error' ? (
+        <RoleErrorMessage>{state.message}</RoleErrorMessage>
+      ) : state.kind === 'empty' ? (
         <NoDescriptionBody />
       ) : (
-        <DescriptionBody description={description} selectedYear={selectedYear} />
+        <DescriptionBody description={state.description} selectedYear={selectedYear} />
       )}
     </BottomSheet>
   );

--- a/apps/frontend/src/components/territory-info/territory-info-panel.tsx
+++ b/apps/frontend/src/components/territory-info/territory-info-panel.tsx
@@ -27,7 +27,7 @@ function PanelWrapper({
       aria-labelledby="territory-info-title"
       aria-busy={busy || undefined}
       className={cn(
-        'absolute left-4 top-4 z-30 w-96 max-w-[calc(100vw-2rem)] rounded-lg bg-gray-700/95 p-4 shadow-xl backdrop-blur-sm',
+        'absolute left-4 top-4 z-30 w-96 max-w-[calc(100vw-2rem)] rounded-lg border-l-4 border-role-selected bg-gray-700/95 p-4 shadow-xl backdrop-blur-sm',
         scrollable && 'max-h-[calc(100vh-2rem)] overflow-y-auto',
       )}
     >
@@ -171,7 +171,7 @@ function MobileContent({
       isOpen
       onClose={onClose}
       header={
-        <div className="px-4">
+        <div className="border-l-4 border-role-selected px-4">
           <PanelHeader name={headerName} era={headerEra} onClose={onClose} />
         </div>
       }

--- a/apps/frontend/src/components/territory-info/territory-info-panel.tsx
+++ b/apps/frontend/src/components/territory-info/territory-info-panel.tsx
@@ -7,7 +7,10 @@ import { cn } from '@/lib/utils';
 import { useAppState } from '../../contexts/app-state-context';
 import { BottomSheet } from '../bottom-sheet/bottom-sheet';
 import { CloseButton } from '../close-button/close-button';
+import { RoleErrorMessage } from '../feedback/role-error-message';
+import { RoleSpinner } from '../feedback/role-spinner';
 import { useTerritoryDescription } from './hooks/use-territory-description';
+import { SELECTED_ACCENT_CLASS, SelectedAccent } from './selected-accent';
 import { TerritoryProfile } from './territory-profile';
 import { TerritoryTimeline } from './territory-timeline';
 
@@ -27,7 +30,8 @@ function PanelWrapper({
       aria-labelledby="territory-info-title"
       aria-busy={busy || undefined}
       className={cn(
-        'absolute left-4 top-4 z-30 w-96 max-w-[calc(100vw-2rem)] rounded-lg border-l-4 border-role-selected bg-gray-700/95 p-4 shadow-xl backdrop-blur-sm',
+        'absolute left-4 top-4 z-30 w-96 max-w-[calc(100vw-2rem)] rounded-lg bg-gray-700/95 p-4 shadow-xl backdrop-blur-sm',
+        SELECTED_ACCENT_CLASS,
         scrollable && 'max-h-[calc(100vh-2rem)] overflow-y-auto',
       )}
     >
@@ -60,18 +64,6 @@ function PanelHeader({
       <CloseButton onClick={onClose} aria-label="閉じる" />
     </div>
   );
-}
-
-function LoadingBody() {
-  return (
-    <div className="flex items-center justify-center py-8">
-      <div className="h-8 w-8 animate-spin rounded-full border-4 border-role-loading border-t-transparent" />
-    </div>
-  );
-}
-
-function ErrorBody({ error }: { error: string | null }) {
-  return <p className="m-3 rounded p-3 bg-role-error/10 text-role-error">{error}</p>;
 }
 
 function NoDescriptionBody() {
@@ -121,7 +113,7 @@ function DesktopContent({
     return (
       <PanelWrapper busy>
         <PanelHeader name={selectedTerritory ?? '読み込み中…'} onClose={onClose} />
-        <LoadingBody />
+        <RoleSpinner />
       </PanelWrapper>
     );
   }
@@ -129,7 +121,7 @@ function DesktopContent({
     return (
       <PanelWrapper>
         <PanelHeader name="エラー" onClose={onClose} />
-        <ErrorBody error={error} />
+        <RoleErrorMessage>{error}</RoleErrorMessage>
       </PanelWrapper>
     );
   }
@@ -171,16 +163,16 @@ function MobileContent({
       isOpen
       onClose={onClose}
       header={
-        <div className="border-l-4 border-role-selected px-4">
+        <SelectedAccent className="px-4">
           <PanelHeader name={headerName} era={headerEra} onClose={onClose} />
-        </div>
+        </SelectedAccent>
       }
       aria-labelledby="territory-info-title"
     >
       {isLoading ? (
-        <LoadingBody />
+        <RoleSpinner />
       ) : error ? (
-        <ErrorBody error={error} />
+        <RoleErrorMessage>{error}</RoleErrorMessage>
       ) : !description ? (
         <NoDescriptionBody />
       ) : (

--- a/apps/frontend/src/components/territory-info/territory-timeline.stories.tsx
+++ b/apps/frontend/src/components/territory-info/territory-timeline.stories.tsx
@@ -32,31 +32,38 @@ const meta = {
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-export const SelectedYearInMiddle: Story = {
-  args: {
-    keyEvents: sampleEvents,
-    selectedYear: createHistoricalYear(1700),
-  },
-};
-
-export const SelectedYearMatchesEvent: Story = {
+export const CurrentYearMatchesEvent: Story = {
   args: {
     keyEvents: sampleEvents,
     selectedYear: createHistoricalYear(1682),
   },
 };
 
-export const SelectedYearBeforeAll: Story = {
+export const CurrentYearBetweenEvents: Story = {
+  args: {
+    keyEvents: sampleEvents,
+    selectedYear: createHistoricalYear(1700),
+  },
+};
+
+export const CurrentYearBeforeAll: Story = {
   args: {
     keyEvents: sampleEvents,
     selectedYear: createHistoricalYear(1600),
   },
 };
 
-export const SelectedYearAfterAll: Story = {
+export const CurrentYearAfterAll: Story = {
   args: {
     keyEvents: sampleEvents,
     selectedYear: createHistoricalYear(1900),
+  },
+};
+
+export const EmptyEventList: Story = {
+  args: {
+    keyEvents: [],
+    selectedYear: createHistoricalYear(1700),
   },
 };
 

--- a/apps/frontend/src/components/territory-info/territory-timeline.stories.tsx
+++ b/apps/frontend/src/components/territory-info/territory-timeline.stories.tsx
@@ -60,14 +60,14 @@ export const CurrentYearAfterAll: Story = {
   },
 };
 
-export const EmptyEventList: Story = {
+export const KeyEventsEmpty: Story = {
   args: {
     keyEvents: [],
     selectedYear: createHistoricalYear(1700),
   },
 };
 
-export const NoEvents: Story = {
+export const KeyEventsUndefined: Story = {
   args: {
     keyEvents: undefined,
     selectedYear: createHistoricalYear(1700),

--- a/apps/frontend/src/components/territory-info/territory-timeline.test.tsx
+++ b/apps/frontend/src/components/territory-info/territory-timeline.test.tsx
@@ -3,6 +3,7 @@ import { describe, expect, it } from 'vitest';
 import type { KeyEvent } from '@/domain/territory/types';
 import { createHistoricalYear } from '@/domain/year/historical-year';
 import { TerritoryTimeline } from './territory-timeline';
+import { CURRENT_YEAR_LABEL } from './timeline-row-style';
 
 describe('TerritoryTimeline', () => {
   const sampleEvents: KeyEvent[] = [
@@ -68,7 +69,7 @@ describe('TerritoryTimeline', () => {
 
     expect(placeholder).toBeInTheDocument();
     expect(placeholder?.textContent).toContain('1700');
-    expect(placeholder?.textContent).toContain('現在');
+    expect(placeholder?.textContent).toContain(CURRENT_YEAR_LABEL);
   });
 
   it('renders nothing when keyEvents is undefined', () => {
@@ -101,7 +102,7 @@ describe('TerritoryTimeline', () => {
     const lastItem = items[items.length - 1];
 
     expect(lastItem).toHaveAttribute('aria-current', 'true');
-    expect(lastItem?.textContent).toContain('現在');
+    expect(lastItem?.textContent).toContain(CURRENT_YEAR_LABEL);
   });
 
   it('places placeholder row first when all events are future', () => {
@@ -119,6 +120,6 @@ describe('TerritoryTimeline', () => {
     const firstItem = items[0];
 
     expect(firstItem).toHaveAttribute('aria-current', 'true');
-    expect(firstItem?.textContent).toContain('現在');
+    expect(firstItem?.textContent).toContain(CURRENT_YEAR_LABEL);
   });
 });

--- a/apps/frontend/src/components/territory-info/territory-timeline.test.tsx
+++ b/apps/frontend/src/components/territory-info/territory-timeline.test.tsx
@@ -14,7 +14,7 @@ describe('TerritoryTimeline', () => {
     { year: 1789, event: 'フランス革命' },
   ];
 
-  it('applies opacity/muted styling classes to past events', () => {
+  it('applies opacity styling to past events', () => {
     render(
       <TerritoryTimeline keyEvents={sampleEvents} selectedYear={createHistoricalYear(1700)} />,
     );
@@ -40,7 +40,7 @@ describe('TerritoryTimeline', () => {
     expect(currentItem?.className).toMatch(/font-semibold|font-bold/);
   });
 
-  it('applies dashed/muted style to future events', () => {
+  it('applies opacity to future events', () => {
     render(
       <TerritoryTimeline keyEvents={sampleEvents} selectedYear={createHistoricalYear(1700)} />,
     );
@@ -50,10 +50,9 @@ describe('TerritoryTimeline', () => {
     const futureItem = items.find((item) => item.textContent?.includes('1789'));
 
     expect(futureItem?.className).toMatch(/opacity/);
-    expect(futureItem?.className).toMatch(/dashed|border-dashed/);
   });
 
-  it('shows year marker at the correct position when no exact match event exists', () => {
+  it('inserts a current-year placeholder row when no exact event matches', () => {
     const eventsNoMatch: KeyEvent[] = [
       { year: 1643, event: 'ルイ14世即位' },
       { year: 1789, event: 'フランス革命' },
@@ -63,9 +62,13 @@ describe('TerritoryTimeline', () => {
       <TerritoryTimeline keyEvents={eventsNoMatch} selectedYear={createHistoricalYear(1700)} />,
     );
 
-    const marker = screen.getByRole('separator');
-    expect(marker).toBeInTheDocument();
-    expect(marker).toHaveAttribute('aria-label', expect.stringContaining('1700'));
+    const list = screen.getByRole('list');
+    const items = within(list).getAllByRole('listitem');
+    const placeholder = items.find((item) => item.getAttribute('aria-current') === 'true');
+
+    expect(placeholder).toBeInTheDocument();
+    expect(placeholder?.textContent).toContain('1700');
+    expect(placeholder?.textContent).toContain('現在');
   });
 
   it('renders nothing when keyEvents is undefined', () => {
@@ -85,7 +88,7 @@ describe('TerritoryTimeline', () => {
     expect(list).toHaveAttribute('aria-label', '主な出来事');
   });
 
-  it('places marker at the end when all events are past', () => {
+  it('places placeholder row last when all events are past', () => {
     const pastEvents: KeyEvent[] = [
       { year: 1600, event: '過去A' },
       { year: 1650, event: '過去B' },
@@ -94,15 +97,14 @@ describe('TerritoryTimeline', () => {
     render(<TerritoryTimeline keyEvents={pastEvents} selectedYear={createHistoricalYear(1700)} />);
 
     const list = screen.getByRole('list');
-    const marker = within(list).getByRole('separator');
-    expect(marker).toBeInTheDocument();
+    const items = within(list).getAllByRole('listitem');
+    const lastItem = items[items.length - 1];
 
-    const markerLi = marker.closest('li');
-    const children = Array.from(list.children);
-    expect(children[children.length - 1]).toBe(markerLi);
+    expect(lastItem).toHaveAttribute('aria-current', 'true');
+    expect(lastItem?.textContent).toContain('現在');
   });
 
-  it('places marker at the beginning when all events are future', () => {
+  it('places placeholder row first when all events are future', () => {
     const futureEvents: KeyEvent[] = [
       { year: 1800, event: '未来A' },
       { year: 1900, event: '未来B' },
@@ -113,11 +115,10 @@ describe('TerritoryTimeline', () => {
     );
 
     const list = screen.getByRole('list');
-    const marker = within(list).getByRole('separator');
-    expect(marker).toBeInTheDocument();
+    const items = within(list).getAllByRole('listitem');
+    const firstItem = items[0];
 
-    const markerLi = marker.closest('li');
-    const children = Array.from(list.children);
-    expect(children[0]).toBe(markerLi);
+    expect(firstItem).toHaveAttribute('aria-current', 'true');
+    expect(firstItem?.textContent).toContain('現在');
   });
 });

--- a/apps/frontend/src/components/territory-info/territory-timeline.tsx
+++ b/apps/frontend/src/components/territory-info/territory-timeline.tsx
@@ -62,6 +62,7 @@ export function TerritoryTimeline({
             className={cn(
               'relative flex items-center gap-2.5',
               isCurrent ? 'py-2 font-semibold' : 'py-1.5',
+              !isCurrent && row.temporal === 'past' && 'opacity-70',
               isFuture && 'opacity-60',
             )}
           >

--- a/apps/frontend/src/components/territory-info/territory-timeline.tsx
+++ b/apps/frontend/src/components/territory-info/territory-timeline.tsx
@@ -1,36 +1,8 @@
 import { useMemo } from 'react';
-import { classifyEvents } from '@/domain/territory/classify-events';
-import type { ClassifiedKeyEvent, KeyEvent } from '@/domain/territory/types';
+import { TimelineRows } from '@/domain/territory/timeline-rows';
+import type { KeyEvent } from '@/domain/territory/types';
 import type { HistoricalYear } from '@/domain/year/historical-year';
-import { cn } from '@/lib/utils';
-
-type EventRow =
-  | (ClassifiedKeyEvent & { kind: 'classified' })
-  | { kind: 'placeholder'; year: number; event: string; temporal: 'current' };
-
-function buildRows(keyEvents: KeyEvent[], selectedYear: HistoricalYear): EventRow[] {
-  if (keyEvents.length === 0) {
-    return [{ kind: 'placeholder', year: selectedYear, event: '現在', temporal: 'current' }];
-  }
-
-  const classified = classifyEvents(keyEvents, selectedYear);
-  const hasCurrent = classified.some((e) => e.temporal === 'current');
-
-  if (hasCurrent) {
-    return classified.map((e) => ({ ...e, kind: 'classified' as const }));
-  }
-
-  const rows: EventRow[] = classified.map((e) => ({ ...e, kind: 'classified' as const }));
-  const insertIndex = classified.findIndex((e) => e.temporal === 'future');
-  const placeholder: EventRow = {
-    kind: 'placeholder',
-    year: selectedYear,
-    event: '現在',
-    temporal: 'current',
-  };
-  rows.splice(insertIndex === -1 ? rows.length : insertIndex, 0, placeholder);
-  return rows;
-}
+import { CURRENT_YEAR_LABEL, timelineRowStyleFor } from './timeline-row-style';
 
 export function TerritoryTimeline({
   keyEvents,
@@ -39,12 +11,12 @@ export function TerritoryTimeline({
   keyEvents: KeyEvent[] | undefined;
   selectedYear: HistoricalYear;
 }) {
-  const rows = useMemo(
-    () => (keyEvents ? buildRows(keyEvents, selectedYear) : []),
+  const timelineRows = useMemo(
+    () => TimelineRows.from(keyEvents, selectedYear),
     [keyEvents, selectedYear],
   );
 
-  if (!keyEvents) return null;
+  if (!timelineRows.hasContent()) return null;
 
   return (
     <ol aria-label="主な出来事" className="relative list-none pl-3.5">
@@ -52,41 +24,19 @@ export function TerritoryTimeline({
         aria-hidden
         className="pointer-events-none absolute bottom-2 left-[3px] top-2 w-px bg-surface-border"
       />
-      {rows.map((row) => {
+      {timelineRows.rows().map((row) => {
+        const style = timelineRowStyleFor(row.temporal);
+        const eventLabel = row.kind === 'classified' ? row.event : CURRENT_YEAR_LABEL;
         const isCurrent = row.temporal === 'current';
-        const isFuture = row.temporal === 'future';
         return (
           <li
-            key={`${row.kind}-${row.year}-${row.event}`}
+            key={`${row.kind}-${row.year}`}
             aria-current={isCurrent ? 'true' : undefined}
-            className={cn(
-              'relative flex items-center gap-2.5',
-              isCurrent ? 'py-2 font-semibold' : 'py-1.5',
-              !isCurrent && row.temporal === 'past' && 'opacity-70',
-              isFuture && 'opacity-60',
-            )}
+            className={style.rowClassName}
           >
-            <span
-              aria-hidden
-              className={cn(
-                'absolute top-1/2 -translate-y-1/2 shrink-0 rounded-full',
-                isCurrent
-                  ? '-left-[15px] size-[9px] border-2 border-surface-panel bg-role-selected'
-                  : '-left-3 size-[3px] bg-text-quiet',
-              )}
-              style={isCurrent ? { boxShadow: '0 0 8px var(--color-role-selected)' } : undefined}
-            />
-            <span
-              className={cn(
-                'shrink-0 text-xs tabular-nums',
-                isCurrent ? 'text-role-selected' : 'text-text-tertiary',
-              )}
-            >
-              {row.year}
-            </span>
-            <span className={cn('text-sm', isCurrent ? 'text-white' : 'text-text-secondary')}>
-              {row.event}
-            </span>
+            <span aria-hidden className={style.markerClassName} style={style.markerInlineStyle} />
+            <span className={style.yearClassName}>{row.year}</span>
+            <span className={style.eventClassName}>{eventLabel}</span>
           </li>
         );
       })}

--- a/apps/frontend/src/components/territory-info/territory-timeline.tsx
+++ b/apps/frontend/src/components/territory-info/territory-timeline.tsx
@@ -1,8 +1,36 @@
-import { Fragment, useMemo } from 'react';
+import { useMemo } from 'react';
 import { classifyEvents } from '@/domain/territory/classify-events';
-import type { KeyEvent } from '@/domain/territory/types';
+import type { ClassifiedKeyEvent, KeyEvent } from '@/domain/territory/types';
 import type { HistoricalYear } from '@/domain/year/historical-year';
 import { cn } from '@/lib/utils';
+
+type EventRow =
+  | (ClassifiedKeyEvent & { kind: 'classified' })
+  | { kind: 'placeholder'; year: number; event: string; temporal: 'current' };
+
+function buildRows(keyEvents: KeyEvent[], selectedYear: HistoricalYear): EventRow[] {
+  if (keyEvents.length === 0) {
+    return [{ kind: 'placeholder', year: selectedYear, event: '現在', temporal: 'current' }];
+  }
+
+  const classified = classifyEvents(keyEvents, selectedYear);
+  const hasCurrent = classified.some((e) => e.temporal === 'current');
+
+  if (hasCurrent) {
+    return classified.map((e) => ({ ...e, kind: 'classified' as const }));
+  }
+
+  const rows: EventRow[] = classified.map((e) => ({ ...e, kind: 'classified' as const }));
+  const insertIndex = classified.findIndex((e) => e.temporal === 'future');
+  const placeholder: EventRow = {
+    kind: 'placeholder',
+    year: selectedYear,
+    event: '現在',
+    temporal: 'current',
+  };
+  rows.splice(insertIndex === -1 ? rows.length : insertIndex, 0, placeholder);
+  return rows;
+}
 
 export function TerritoryTimeline({
   keyEvents,
@@ -11,68 +39,56 @@ export function TerritoryTimeline({
   keyEvents: KeyEvent[] | undefined;
   selectedYear: HistoricalYear;
 }) {
-  const classified = useMemo(
-    () => (keyEvents ? classifyEvents(keyEvents, selectedYear) : []),
+  const rows = useMemo(
+    () => (keyEvents ? buildRows(keyEvents, selectedYear) : []),
     [keyEvents, selectedYear],
   );
 
-  if (!keyEvents || keyEvents.length === 0) return null;
-
-  const hasCurrent = classified.some((event) => event.temporal === 'current');
-
-  const markerIndex = hasCurrent
-    ? -1
-    : classified.findIndex((event) => event.temporal === 'future');
-
-  const resolvedMarkerIndex = markerIndex === -1 && !hasCurrent ? classified.length : markerIndex;
-
-  const yearMarker = !hasCurrent && (
-    <li key="year-marker" role="none" className="py-2">
-      <hr aria-label={`${selectedYear}年`} className="flex items-center gap-2 border-0" />
-      <span className="flex items-center gap-2">
-        <span className="h-px flex-1 bg-gray-500" />
-        <span className="shrink-0 text-xs font-medium text-gray-400">{selectedYear}年</span>
-        <span className="h-px flex-1 bg-gray-500" />
-      </span>
-    </li>
-  );
+  if (!keyEvents) return null;
 
   return (
-    <ol aria-label="主な出来事" className="space-y-1">
-      {classified.map((event, i) => {
-        const isPast = event.temporal === 'past';
-        const isCurrent = event.temporal === 'current';
-        const isFuture = event.temporal === 'future';
-
+    <ol aria-label="主な出来事" className="relative list-none pl-3.5">
+      <span
+        aria-hidden
+        className="pointer-events-none absolute bottom-2 left-[3px] top-2 w-px bg-surface-border"
+      />
+      {rows.map((row) => {
+        const isCurrent = row.temporal === 'current';
+        const isFuture = row.temporal === 'future';
         return (
-          <Fragment key={`${event.year}-${event.event}`}>
-            {resolvedMarkerIndex === i && yearMarker}
-            <li
-              aria-current={isCurrent ? 'true' : undefined}
+          <li
+            key={`${row.kind}-${row.year}-${row.event}`}
+            aria-current={isCurrent ? 'true' : undefined}
+            className={cn(
+              'relative flex items-center gap-2.5',
+              isCurrent ? 'py-2 font-semibold' : 'py-1.5',
+              isFuture && 'opacity-60',
+            )}
+          >
+            <span
+              aria-hidden
               className={cn(
-                'flex items-start gap-3 py-1.5',
-                isPast && 'opacity-75',
-                isCurrent && 'font-semibold',
-                isFuture && 'opacity-60 border-dashed',
+                'absolute top-1/2 -translate-y-1/2 shrink-0 rounded-full',
+                isCurrent
+                  ? '-left-[15px] size-[9px] border-2 border-surface-panel bg-role-selected'
+                  : '-left-3 size-[3px] bg-text-quiet',
+              )}
+              style={isCurrent ? { boxShadow: '0 0 8px var(--color-role-selected)' } : undefined}
+            />
+            <span
+              className={cn(
+                'shrink-0 text-xs tabular-nums',
+                isCurrent ? 'text-role-selected' : 'text-text-tertiary',
               )}
             >
-              <span
-                className={cn(
-                  'mt-1.5 inline-block size-2.5 shrink-0 rounded-full',
-                  isPast && 'bg-slate-400',
-                  isCurrent && 'ring-2 ring-white bg-white',
-                  isFuture && 'border border-dashed border-slate-400',
-                )}
-              />
-              <span className="shrink-0 text-sm tabular-nums text-gray-300">{event.year}</span>
-              <span className={cn('text-sm', isCurrent ? 'text-white' : 'text-gray-300')}>
-                {event.event}
-              </span>
-            </li>
-          </Fragment>
+              {row.year}
+            </span>
+            <span className={cn('text-sm', isCurrent ? 'text-white' : 'text-text-secondary')}>
+              {row.event}
+            </span>
+          </li>
         );
       })}
-      {resolvedMarkerIndex === classified.length && yearMarker}
     </ol>
   );
 }

--- a/apps/frontend/src/components/territory-info/timeline-row-style.ts
+++ b/apps/frontend/src/components/territory-info/timeline-row-style.ts
@@ -1,0 +1,57 @@
+import type { CSSProperties } from 'react';
+import type { KeyEventTemporal } from '@/domain/territory/types';
+
+// Numeric constants for inline styles and documentation of spatial relationships.
+// Do NOT use these in Tailwind class strings (static analysis would fail).
+export const TIMELINE_CURRENT_DOT_GLOW_PX = 8;
+
+export const CURRENT_YEAR_LABEL = '現在';
+
+export interface TimelineRowStyle {
+  readonly rowClassName: string;
+  readonly markerClassName: string;
+  readonly markerInlineStyle: CSSProperties | undefined;
+  readonly yearClassName: string;
+  readonly eventClassName: string;
+}
+
+// Current dot: 9px diameter, centered on the 3px-wide rail with a 2px border
+// → offset left = rail_left(3) + dot_radius(4.5) + border(2) ≈ 9.5 → 15px
+const PAST_ROW_STYLE: TimelineRowStyle = {
+  rowClassName: 'relative flex items-center gap-2.5 py-1.5 opacity-70',
+  markerClassName:
+    'absolute top-1/2 -translate-y-1/2 shrink-0 rounded-full -left-3 size-[3px] bg-text-quiet',
+  markerInlineStyle: undefined,
+  yearClassName: 'shrink-0 text-xs tabular-nums text-text-tertiary',
+  eventClassName: 'text-sm text-text-secondary',
+};
+
+const CURRENT_ROW_STYLE: TimelineRowStyle = {
+  rowClassName: 'relative flex items-center gap-2.5 py-2 font-semibold',
+  markerClassName:
+    'absolute top-1/2 -translate-y-1/2 shrink-0 rounded-full -left-[15px] size-[9px] border-2 border-surface-panel bg-role-selected',
+  markerInlineStyle: {
+    boxShadow: `0 0 ${TIMELINE_CURRENT_DOT_GLOW_PX}px var(--color-role-selected)`,
+  },
+  yearClassName: 'shrink-0 text-xs tabular-nums text-role-selected',
+  eventClassName: 'text-sm text-white',
+};
+
+const FUTURE_ROW_STYLE: TimelineRowStyle = {
+  rowClassName: 'relative flex items-center gap-2.5 py-1.5 opacity-60',
+  markerClassName:
+    'absolute top-1/2 -translate-y-1/2 shrink-0 rounded-full -left-3 size-[3px] bg-text-quiet',
+  markerInlineStyle: undefined,
+  yearClassName: 'shrink-0 text-xs tabular-nums text-text-tertiary',
+  eventClassName: 'text-sm text-text-secondary',
+};
+
+const ROW_STYLES: Record<KeyEventTemporal, TimelineRowStyle> = {
+  past: PAST_ROW_STYLE,
+  current: CURRENT_ROW_STYLE,
+  future: FUTURE_ROW_STYLE,
+};
+
+export function timelineRowStyleFor(temporal: KeyEventTemporal): TimelineRowStyle {
+  return ROW_STYLES[temporal];
+}

--- a/apps/frontend/src/components/year-selector/year-selector.tsx
+++ b/apps/frontend/src/components/year-selector/year-selector.tsx
@@ -154,7 +154,7 @@ export function YearSelector({ years, onYearSelect }: YearSelectorProps) {
               className={cn(
                 'flex shrink-0 items-center justify-center border-r border-gray-600 py-3 font-medium transition-colors last:border-r-0',
                 isSelected
-                  ? 'min-w-[5rem] bg-blue-600 px-5 text-xl text-white'
+                  ? 'min-w-[5rem] bg-surface-raise px-5 text-xl font-bold text-white'
                   : 'min-w-[4rem] px-3 text-base text-gray-300 hover:bg-gray-600 hover:text-white',
               )}
             >

--- a/apps/frontend/src/domain/territory/timeline-rows.test.ts
+++ b/apps/frontend/src/domain/territory/timeline-rows.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from 'vitest';
+import { createHistoricalYear } from '../year/historical-year';
+import { TimelineRows } from './timeline-rows';
+import type { KeyEvent } from './types';
+
+describe('TimelineRows', () => {
+  const year1700 = createHistoricalYear(1700);
+
+  it('returns empty rows with hasContent=false when events is undefined', () => {
+    const rows = TimelineRows.from(undefined, year1700);
+    expect(rows.hasContent()).toBe(false);
+    expect(rows.rows()).toHaveLength(0);
+  });
+
+  it('returns only a current-year marker when events is empty', () => {
+    const rows = TimelineRows.from([], year1700);
+    expect(rows.hasContent()).toBe(true);
+    expect(rows.rows()).toHaveLength(1);
+    expect(rows.rows()[0]).toMatchObject({
+      kind: 'currentYearMarker',
+      year: year1700,
+      temporal: 'current',
+    });
+  });
+
+  it('places marker last when all events are past', () => {
+    const events: KeyEvent[] = [
+      { year: 1600, event: '過去A' },
+      { year: 1650, event: '過去B' },
+    ];
+    const rowList = TimelineRows.from(events, year1700).rows();
+    const lastRow = rowList[rowList.length - 1];
+    expect(lastRow).toMatchObject({ kind: 'currentYearMarker', temporal: 'current' });
+  });
+
+  it('places marker first when all events are future', () => {
+    const events: KeyEvent[] = [
+      { year: 1800, event: '未来A' },
+      { year: 1900, event: '未来B' },
+    ];
+    const rowList = TimelineRows.from(events, year1700).rows();
+    const firstRow = rowList[0];
+    expect(firstRow).toMatchObject({ kind: 'currentYearMarker', temporal: 'current' });
+  });
+
+  it('places marker between past and future events', () => {
+    const events: KeyEvent[] = [
+      { year: 1650, event: '過去' },
+      { year: 1800, event: '未来' },
+    ];
+    const rowList = TimelineRows.from(events, year1700).rows();
+    expect(rowList).toHaveLength(3);
+    expect(rowList[0]).toMatchObject({ kind: 'classified', temporal: 'past' });
+    expect(rowList[1]).toMatchObject({ kind: 'currentYearMarker', temporal: 'current' });
+    expect(rowList[2]).toMatchObject({ kind: 'classified', temporal: 'future' });
+  });
+
+  it('does not insert a marker when an event falls exactly on the selected year', () => {
+    const events: KeyEvent[] = [
+      { year: 1650, event: '過去' },
+      { year: 1700, event: '現在のイベント' },
+      { year: 1800, event: '未来' },
+    ];
+    const rowList = TimelineRows.from(events, year1700).rows();
+    expect(rowList).toHaveLength(3);
+    expect(rowList.every((row) => row.kind === 'classified')).toBe(true);
+    const currentRow = rowList.find((row) => row.temporal === 'current');
+    expect(currentRow).toMatchObject({ kind: 'classified', temporal: 'current' });
+  });
+});

--- a/apps/frontend/src/domain/territory/timeline-rows.ts
+++ b/apps/frontend/src/domain/territory/timeline-rows.ts
@@ -1,0 +1,68 @@
+import type { HistoricalYear } from '../year/historical-year';
+import { classifyEvents } from './classify-events';
+import type { ClassifiedKeyEvent, KeyEvent } from './types';
+
+export type ClassifiedTimelineRow = ClassifiedKeyEvent & { kind: 'classified' };
+
+export type CurrentYearMarkerRow = {
+  kind: 'currentYearMarker';
+  year: HistoricalYear;
+  temporal: 'current';
+};
+
+export type TimelineRow = ClassifiedTimelineRow | CurrentYearMarkerRow;
+
+function toClassifiedRow(event: ClassifiedKeyEvent): ClassifiedTimelineRow {
+  return { ...event, kind: 'classified' };
+}
+
+function buildRowList(events: KeyEvent[], selectedYear: HistoricalYear): TimelineRow[] {
+  const marker: CurrentYearMarkerRow = {
+    kind: 'currentYearMarker',
+    year: selectedYear,
+    temporal: 'current',
+  };
+
+  if (events.length === 0) {
+    return [marker];
+  }
+
+  const classified = classifyEvents(events, selectedYear);
+  const hasCurrentEvent = classified.some((event) => event.temporal === 'current');
+
+  if (hasCurrentEvent) {
+    return classified.map(toClassifiedRow);
+  }
+
+  const firstFutureIndex = classified.findIndex((event) => event.temporal === 'future');
+  const pivot = firstFutureIndex === -1 ? classified.length : firstFutureIndex;
+
+  return [
+    ...classified.slice(0, pivot).map(toClassifiedRow),
+    marker,
+    ...classified.slice(pivot).map(toClassifiedRow),
+  ];
+}
+
+export class TimelineRows {
+  private readonly _rows: readonly TimelineRow[];
+
+  private constructor(rows: readonly TimelineRow[]) {
+    this._rows = rows;
+  }
+
+  static from(events: KeyEvent[] | undefined, selectedYear: HistoricalYear): TimelineRows {
+    if (events === undefined) {
+      return new TimelineRows([]);
+    }
+    return new TimelineRows(buildRowList(events, selectedYear));
+  }
+
+  rows(): readonly TimelineRow[] {
+    return this._rows;
+  }
+
+  hasContent(): boolean {
+    return this._rows.length > 0;
+  }
+}

--- a/apps/frontend/src/index.css
+++ b/apps/frontend/src/index.css
@@ -17,7 +17,7 @@
   --color-primary-950: oklch(0.20 0.06 250);
 
   --color-role-selected: oklch(0.65 0.22 15);
-  --color-role-state: oklch(0.78 0.14 165);
+  --color-role-loading: oklch(0.78 0.14 165);
   --color-role-warn: oklch(0.78 0.16 75);
   --color-role-error: oklch(0.65 0.22 27);
   --color-role-focus: oklch(0.55 0.18 250);

--- a/apps/frontend/src/index.css
+++ b/apps/frontend/src/index.css
@@ -15,6 +15,22 @@
   --color-primary-800: oklch(0.34 0.12 250);
   --color-primary-900: oklch(0.28 0.09 250);
   --color-primary-950: oklch(0.20 0.06 250);
+
+  --color-role-selected: oklch(0.65 0.22 15);
+  --color-role-state: oklch(0.78 0.14 165);
+  --color-role-warn: oklch(0.78 0.16 75);
+  --color-role-error: oklch(0.65 0.22 27);
+  --color-role-focus: oklch(0.55 0.18 250);
+
+  --color-surface-base: oklch(0.16 0.01 250);
+  --color-surface-panel: oklch(0.30 0.01 250 / 0.95);
+  --color-surface-raise: oklch(1 0 0 / 0.14);
+  --color-surface-border: oklch(0.40 0.01 250);
+
+  --color-text-primary: oklch(1 0 0);
+  --color-text-secondary: oklch(0.87 0 0);
+  --color-text-tertiary: oklch(0.71 0 0);
+  --color-text-quiet: oklch(0.55 0 0);
 }
 
 :root {
@@ -42,7 +58,7 @@ body {
   }
 
   :focus-visible {
-    outline: 2px solid oklch(0.55 0.18 250); /* primary-500 */
+    outline: 2px solid var(--color-role-focus);
     outline-offset: 2px;
   }
 


### PR DESCRIPTION
## 概要

close #143

UI の色が「選択中の年」「処理中」「フォーカス」の 3 役を青 1 色で兼ねていた問題を解消しました。役割色トークンを導入して各状態に専用色を割り当て、「主な出来事」タイムラインを縦レール + 赤マーカー形式に刷新しました。

### 背景

- `bg-blue-600`（年バー選択中）・`border-blue-400`（ローディングスピナー）・`outline: primary-500`（フォーカスリング）が同じ青で表現されており、色から状態を判断できない
- マップ上の選択中領土が白オーバーレイで表示されており、「どこが主役か」が視覚的に伝わらない
- 「主な出来事」タイムラインは形状（●/○/破線）と透明度の組み合わせで状態を表現しており、現在年の視認性が低い

### 変更内容

**色の役割分離（1 色 = 1 意味の原則）**

- Tailwind v4 の `@theme` ブロックに `role-selected`（rose）/ `role-state`（green）/ `role-error`（red）/ `role-focus`（blue）などの役割色トークンを追加しました
- 年バーの現在年セル: `bg-blue-600` → 白オーバーレイ（`bg-surface-raise`）に変更しました。青は「フォーカス」専用になりました
- ローディングスピナー（全画面・パネル内）: blue → green（`role-state`）に変更しました
- エラー表示: `text-red-400` → 背景付き帯スタイル（`bg-role-error/10 text-role-error`）に変更しました
- マップ上の選択中領土ハイライト: 白 → 赤（`role-selected` と同値）に変更しました
- キーボードフォーカスリングは blue を維持しました（`role-focus` トークンに切り出して意味を明示）

**「主な出来事」タイムラインの再デザイン（V3 + A3）**

- 縦レール（1 px）を左端に配置し、各イベントを小さな灰色ドットで示すようにしました
- 現在年のイベント: 大きな赤い発光マーカー（glow）＋ 赤テキストで表示します
- 選択年に該当イベントがない場合: 「YYYY · 現在」専用行を時系列順に挿入します（A3）
- イベントが 0 件の領土でも「YYYY · 現在」の 1 行を表示するようにしました

**パネルアクセント**

- 領土情報パネル（デスクトップ・モバイル）の左端に 4 px の `role-selected`（赤）アクセントバーを追加しました

**注意点**

MapLibre の paint プロパティは CSS 変数を解釈できないため、選択中領土のハイライト色は `territory-style-constants.ts` に hex 値をハードコードしています。`index.css` の `--color-role-selected` と同じ値であることをファイル内コメントで明示しています。

## 動作確認

- [ ] 領土をクリックすると、マップ上のハイライトが赤系で表示される（白ではない）
- [ ] 年バーの選択中年セルが青ではなく白オーバーレイで表示される
- [ ] タイル読み込み中のグローブスピナーが緑で回る
- [ ] 領土情報パネルのロード中スピナーが緑で回る
- [ ] キーボード Tab キーでフォーカスリングが引き続き青で表示される
- [ ] 「主な出来事」で選択年に出来事がある → 該当行に赤い発光マーカーが表示される
- [ ] 「主な出来事」で選択年に出来事がない → 「YYYY · 現在」行が時系列順に挿入される
- [ ] 「主な出来事」が 0 件の領土を選択 → 「YYYY · 現在」の 1 行のみ表示される
- [ ] 領土情報パネル（デスクトップ）の左端に赤い 4 px バーが表示される
- [ ] モバイルのボトムシートヘッダー左端にも赤い 4 px バーが表示される

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
