### PR TITLE
feat(design-tokens): introduce build step to unify CSS/TS role color definitions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,3 +98,29 @@ jobs:
 
       - name: Build
         run: pnpm build
+
+  verify-generated:
+    name: Verify Generated Files
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v6
+        with:
+          version: 10
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Check design-tokens are up to date
+        run: pnpm --filter @world-history-map/design-tokens run build:check
+
+      - name: Check tiles manifest is up to date
+        run: pnpm --filter @world-history-map/tiles run build:check

--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ dist
 dist-ssr
 build
 !packages/tiles/src/build
+!packages/design-tokens/src/build
 
 # Local env files
 *.local

--- a/apps/frontend/package.json
+++ b/apps/frontend/package.json
@@ -4,8 +4,9 @@
   "version": "0.0.1",
   "type": "module",
   "scripts": {
-    "predev": "pnpm --filter @world-history-map/tiles run build",
+    "predev": "pnpm --filter @world-history-map/tiles run build && pnpm --filter @world-history-map/design-tokens run build",
     "dev": "vite",
+    "prebuild": "pnpm --filter @world-history-map/design-tokens run build",
     "build": "tsc -b && vite build",
     "preview": "vite preview",
     "test": "vitest run",
@@ -14,6 +15,7 @@
     "build-storybook": "storybook build"
   },
   "dependencies": {
+    "@world-history-map/design-tokens": "workspace:*",
     "@world-history-map/tiles": "workspace:*",
     "clsx": "^2.1.1",
     "maplibre-gl": "^5.24.0",

--- a/apps/frontend/src/components/map/territory-style-constants.ts
+++ b/apps/frontend/src/components/map/territory-style-constants.ts
@@ -1,3 +1,4 @@
+import { roleColors } from '@world-history-map/design-tokens';
 import type { ExpressionSpecification } from 'maplibre-gl';
 
 export const LABEL_TEXT_COLOR = '#f0f0f0';
@@ -44,9 +45,7 @@ export const LABEL_ANCHOR: ('center' | 'top' | 'bottom' | 'left' | 'right')[] = 
 
 export const TERRITORY_FILL_OPACITY = 0.7;
 
-// Mirrors --color-role-selected from index.css.
-// MapLibre paint props cannot reference CSS variables.
-export const HIGHLIGHT_COLOR = '#f43f5e';
+export const HIGHLIGHT_COLOR = roleColors.selected;
 export const HIGHLIGHT_FILL_OPACITY = 0.2;
 export const HIGHLIGHT_LINE_WIDTH = 3.5;
 

--- a/apps/frontend/src/components/year-selector/year-selector.tsx
+++ b/apps/frontend/src/components/year-selector/year-selector.tsx
@@ -154,7 +154,7 @@ export function YearSelector({ years, onYearSelect }: YearSelectorProps) {
               className={cn(
                 'flex shrink-0 items-center justify-center border-r border-gray-600 py-3 font-medium transition-colors last:border-r-0',
                 isSelected
-                  ? 'min-w-[5rem] bg-surface-raise px-5 text-xl font-bold text-white'
+                  ? 'min-w-[5rem] bg-surface-raised px-5 text-xl font-bold text-white'
                   : 'min-w-[4rem] px-3 text-base text-gray-300 hover:bg-gray-600 hover:text-white',
               )}
             >

--- a/apps/frontend/src/domain/territory/description-loader.ts
+++ b/apps/frontend/src/domain/territory/description-loader.ts
@@ -18,7 +18,7 @@ function getYearFetcher(year: HistoricalYear): CachedFetcher<YearDescriptionBund
       }
 
       const contentType = response.headers.get('content-type');
-      if (!contentType || !contentType.includes('application/json')) return null;
+      if (!contentType?.includes('application/json')) return null;
 
       return response.json() as Promise<YearDescriptionBundle>;
     },

--- a/apps/frontend/src/index.css
+++ b/apps/frontend/src/index.css
@@ -1,37 +1,8 @@
 @import "tailwindcss";
+@import "@world-history-map/design-tokens/theme.css";
 
 /* Class-based dark mode (toggle with .dark class on html element) */
 @custom-variant dark (&:where(.dark, .dark *));
-
-@theme {
-  --color-primary-50: oklch(0.97 0.01 250);
-  --color-primary-100: oklch(0.93 0.03 250);
-  --color-primary-200: oklch(0.86 0.06 250);
-  --color-primary-300: oklch(0.76 0.10 250);
-  --color-primary-400: oklch(0.64 0.15 250);
-  --color-primary-500: oklch(0.55 0.18 250);
-  --color-primary-600: oklch(0.47 0.18 250);
-  --color-primary-700: oklch(0.40 0.16 250);
-  --color-primary-800: oklch(0.34 0.12 250);
-  --color-primary-900: oklch(0.28 0.09 250);
-  --color-primary-950: oklch(0.20 0.06 250);
-
-  --color-role-selected: oklch(0.65 0.22 15);
-  --color-role-loading: oklch(0.78 0.14 165);
-  --color-role-warn: oklch(0.78 0.16 75);
-  --color-role-error: oklch(0.65 0.22 27);
-  --color-role-focus: oklch(0.55 0.18 250);
-
-  --color-surface-base: oklch(0.16 0.01 250);
-  --color-surface-panel: oklch(0.30 0.01 250 / 0.95);
-  --color-surface-raise: oklch(1 0 0 / 0.14);
-  --color-surface-border: oklch(0.40 0.01 250);
-
-  --color-text-primary: oklch(1 0 0);
-  --color-text-secondary: oklch(0.87 0 0);
-  --color-text-tertiary: oklch(0.71 0 0);
-  --color-text-quiet: oklch(0.55 0 0);
-}
 
 :root {
   font-family: system-ui, Avenir, Helvetica, Arial, sans-serif;

--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.4.7/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.4.14/schema.json",
   "vcs": {
     "enabled": true,
     "clientKind": "git",
@@ -15,6 +15,7 @@
       "!**/coverage",
       "!apps/frontend/public",
       "!apps/frontend/src/index.css",
+      "!packages/design-tokens/src/theme.css",
       "!.claude/worktrees"
     ]
   },

--- a/packages/design-tokens/package.json
+++ b/packages/design-tokens/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "@world-history-map/design-tokens",
+  "private": true,
+  "version": "0.0.1",
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts",
+    "./theme.css": "./src/theme.css"
+  },
+  "scripts": {
+    "build": "tsx src/build/cli.ts",
+    "build:check": "tsx src/build/cli.ts --check",
+    "predev": "pnpm run build",
+    "test": "vitest run",
+    "test:coverage": "vitest run --coverage"
+  },
+  "devDependencies": {
+    "@types/node": "^25.6.0",
+    "@vitest/coverage-v8": "^4.1.5",
+    "tsx": "^4.19.4",
+    "vitest": "^4.1.5"
+  }
+}

--- a/packages/design-tokens/src/build/cli.ts
+++ b/packages/design-tokens/src/build/cli.ts
@@ -1,0 +1,27 @@
+import { writeFile } from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { RoleColorsBuilder } from './role-colors-builder.ts';
+
+const PACKAGE_ROOT = path.resolve(fileURLToPath(import.meta.url), '../../..');
+const DEFAULT_THEME_CSS_PATH = path.join(PACKAGE_ROOT, 'src/theme.css');
+const DEFAULT_OUTPUT_PATH = path.join(PACKAGE_ROOT, 'src/role-colors.generated.ts');
+
+async function runBuild(): Promise<void> {
+  const builder = new RoleColorsBuilder(DEFAULT_THEME_CSS_PATH, DEFAULT_OUTPUT_PATH);
+  const source = await builder.generateSource();
+  await writeFile(DEFAULT_OUTPUT_PATH, source);
+  console.log('Generated role-colors.generated.ts');
+}
+
+async function runCheck(): Promise<void> {
+  const builder = new RoleColorsBuilder(DEFAULT_THEME_CSS_PATH, DEFAULT_OUTPUT_PATH);
+  const isFresh = await builder.isFresh();
+  process.exit(isFresh ? 0 : 1);
+}
+
+const isCheckMode = process.argv.includes('--check');
+(isCheckMode ? runCheck() : runBuild()).catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/packages/design-tokens/src/build/cli.ts
+++ b/packages/design-tokens/src/build/cli.ts
@@ -21,7 +21,7 @@ async function runCheck(): Promise<void> {
 }
 
 const isCheckMode = process.argv.includes('--check');
-(isCheckMode ? runCheck() : runBuild()).catch((err) => {
-  console.error(err);
+(isCheckMode ? runCheck() : runBuild()).catch((error) => {
+  console.error(error);
   process.exit(1);
 });

--- a/packages/design-tokens/src/build/cli.ts
+++ b/packages/design-tokens/src/build/cli.ts
@@ -8,14 +8,14 @@ const DEFAULT_THEME_CSS_PATH = path.join(PACKAGE_ROOT, 'src/theme.css');
 const DEFAULT_OUTPUT_PATH = path.join(PACKAGE_ROOT, 'src/role-colors.generated.ts');
 
 async function runBuild(): Promise<void> {
-  const builder = new RoleColorsBuilder(DEFAULT_THEME_CSS_PATH, DEFAULT_OUTPUT_PATH);
+  const builder = new RoleColorsBuilder({ cssPath: DEFAULT_THEME_CSS_PATH, outputPath: DEFAULT_OUTPUT_PATH });
   const source = await builder.generateSource();
   await writeFile(DEFAULT_OUTPUT_PATH, source);
   console.log('Generated role-colors.generated.ts');
 }
 
 async function runCheck(): Promise<void> {
-  const builder = new RoleColorsBuilder(DEFAULT_THEME_CSS_PATH, DEFAULT_OUTPUT_PATH);
+  const builder = new RoleColorsBuilder({ cssPath: DEFAULT_THEME_CSS_PATH, outputPath: DEFAULT_OUTPUT_PATH });
   const isFresh = await builder.isFresh();
   process.exit(isFresh ? 0 : 1);
 }

--- a/packages/design-tokens/src/build/role-colors-builder.ts
+++ b/packages/design-tokens/src/build/role-colors-builder.ts
@@ -1,0 +1,54 @@
+import { readFile } from 'node:fs/promises';
+
+export type RoleColors = Record<string, string>;
+
+export function extractRoleColors(css: string): RoleColors {
+  const pattern = /--color-role-([a-z]+)\s*:\s*([^;]+?)\s*;/g;
+  const colors: RoleColors = {};
+  for (const match of css.matchAll(pattern)) {
+    const [, name, value] = match;
+    if (name !== undefined && value !== undefined) {
+      colors[name] = value;
+    }
+  }
+  if (Object.keys(colors).length === 0) {
+    throw new Error('No --color-role-* definitions found in CSS');
+  }
+  return colors;
+}
+
+export function toTypeScriptSource(colors: RoleColors): string {
+  const entries = Object.entries(colors)
+    .map(([name, value]) => `  ${name}: '${value}',`)
+    .join('\n');
+  return [
+    '// Generated from packages/design-tokens/src/theme.css. Do not edit by hand.',
+    'export const roleColors = {',
+    entries,
+    '} as const;',
+    '',
+    'export type RoleColorKey = keyof typeof roleColors;',
+    '',
+  ].join('\n');
+}
+
+export class RoleColorsBuilder {
+  private readonly cssPath: string;
+  private readonly outputPath: string;
+
+  constructor(cssPath: string, outputPath: string) {
+    this.cssPath = cssPath;
+    this.outputPath = outputPath;
+  }
+
+  async generateSource(): Promise<string> {
+    const css = await readFile(this.cssPath, 'utf-8');
+    return toTypeScriptSource(extractRoleColors(css));
+  }
+
+  async isFresh(): Promise<boolean> {
+    const newSource = await this.generateSource();
+    const existingSource = await readFile(this.outputPath, 'utf-8').catch(() => null);
+    return existingSource === newSource;
+  }
+}

--- a/packages/design-tokens/src/build/role-colors-builder.ts
+++ b/packages/design-tokens/src/build/role-colors-builder.ts
@@ -24,6 +24,7 @@ export function toTypeScriptSource(colors: RoleColors): string {
     .join('\n');
   return [
     '// Generated from packages/design-tokens/src/theme.css. Do not edit by hand.',
+    '// Run `pnpm --filter @world-history-map/design-tokens run build` to regenerate.',
     'export const roleColors = {',
     entries,
     '} as const;',

--- a/packages/design-tokens/src/build/role-colors-builder.ts
+++ b/packages/design-tokens/src/build/role-colors-builder.ts
@@ -2,6 +2,36 @@ import { readFile } from 'node:fs/promises';
 
 const ROLE_COLOR_VAR_PREFIX = '--color-role-';
 
+function oklchToHex(cssValue: string): string {
+  const match = cssValue.match(/oklch\(\s*([\d.]+)\s+([\d.]+)\s+([\d.]+)\s*\)/);
+  if (!match) throw new Error(`Cannot convert to hex: ${cssValue}`);
+
+  const l = Number(match[1]);
+  const c = Number(match[2]);
+  const h = (Number(match[3]) * Math.PI) / 180;
+
+  const a = c * Math.cos(h);
+  const b = c * Math.sin(h);
+
+  const lp = (l + 0.3963377774 * a + 0.2158037573 * b) ** 3;
+  const mp = (l - 0.1055613458 * a - 0.0638541728 * b) ** 3;
+  const sp = (l - 0.0894841775 * a - 1.291485548 * b) ** 3;
+
+  const rLin = +4.0767416621 * lp - 3.3077115913 * mp + 0.2309699292 * sp;
+  const gLin = -1.2684380046 * lp + 2.6097574011 * mp - 0.3413193965 * sp;
+  const bLin = -0.0041960863 * lp - 0.7034186147 * mp + 1.707614701 * sp;
+
+  const toSrgb = (v: number) => {
+    const clamped = Math.max(0, Math.min(1, v));
+    return clamped <= 0.0031308 ? 12.92 * clamped : 1.055 * clamped ** (1 / 2.4) - 0.055;
+  };
+
+  const r = Math.round(toSrgb(rLin) * 255);
+  const g = Math.round(toSrgb(gLin) * 255);
+  const bv = Math.round(toSrgb(bLin) * 255);
+  return `#${r.toString(16).padStart(2, '0')}${g.toString(16).padStart(2, '0')}${bv.toString(16).padStart(2, '0')}`;
+}
+
 export type RoleColors = Readonly<Record<string, string>>;
 
 export function extractRoleColors(css: string): RoleColors {
@@ -20,7 +50,7 @@ export function extractRoleColors(css: string): RoleColors {
 
 export function toTypeScriptSource(colors: RoleColors): string {
   const entries = Object.entries(colors)
-    .map(([name, value]) => `  ${name}: '${value}',`)
+    .map(([name, value]) => `  ${name}: '${oklchToHex(value)}',`)
     .join('\n');
   return [
     '// Generated from packages/design-tokens/src/theme.css. Do not edit by hand.',

--- a/packages/design-tokens/src/build/role-colors-builder.ts
+++ b/packages/design-tokens/src/build/role-colors-builder.ts
@@ -38,9 +38,9 @@ export class RoleColorsBuilder {
   private readonly cssPath: string;
   private readonly outputPath: string;
 
-  constructor(cssPath: string, outputPath: string) {
-    this.cssPath = cssPath;
-    this.outputPath = outputPath;
+  constructor(paths: { cssPath: string; outputPath: string }) {
+    this.cssPath = paths.cssPath;
+    this.outputPath = paths.outputPath;
   }
 
   async generateSource(): Promise<string> {

--- a/packages/design-tokens/src/build/role-colors-builder.ts
+++ b/packages/design-tokens/src/build/role-colors-builder.ts
@@ -1,9 +1,11 @@
 import { readFile } from 'node:fs/promises';
 
+const ROLE_COLOR_VAR_PREFIX = '--color-role-';
+
 export type RoleColors = Record<string, string>;
 
 export function extractRoleColors(css: string): RoleColors {
-  const pattern = /--color-role-([a-z]+)\s*:\s*([^;]+?)\s*;/g;
+  const pattern = new RegExp(`${ROLE_COLOR_VAR_PREFIX}([a-z]+)\\s*:\\s*([^;]+?)\\s*;`, 'g');
   const colors: RoleColors = {};
   for (const match of css.matchAll(pattern)) {
     const [, name, value] = match;
@@ -12,7 +14,7 @@ export function extractRoleColors(css: string): RoleColors {
     }
   }
   if (Object.keys(colors).length === 0) {
-    throw new Error('No --color-role-* definitions found in CSS');
+    throw new Error(`No ${ROLE_COLOR_VAR_PREFIX}* definitions found in CSS`);
   }
   return colors;
 }

--- a/packages/design-tokens/src/build/role-colors-builder.ts
+++ b/packages/design-tokens/src/build/role-colors-builder.ts
@@ -2,16 +2,15 @@ import { readFile } from 'node:fs/promises';
 
 const ROLE_COLOR_VAR_PREFIX = '--color-role-';
 
-export type RoleColors = Record<string, string>;
+export type RoleColors = Readonly<Record<string, string>>;
 
 export function extractRoleColors(css: string): RoleColors {
   const pattern = new RegExp(`${ROLE_COLOR_VAR_PREFIX}([a-z]+)\\s*:\\s*([^;]+?)\\s*;`, 'g');
-  const colors: RoleColors = {};
+  const colors: Record<string, string> = {};
   for (const match of css.matchAll(pattern)) {
     const [, name, value] = match;
-    if (name !== undefined && value !== undefined) {
-      colors[name] = value;
-    }
+    if (!name || !value) continue;
+    colors[name] = value;
   }
   if (Object.keys(colors).length === 0) {
     throw new Error(`No ${ROLE_COLOR_VAR_PREFIX}* definitions found in CSS`);

--- a/packages/design-tokens/src/index.ts
+++ b/packages/design-tokens/src/index.ts
@@ -1,0 +1,2 @@
+export type { RoleColorKey } from './role-colors.generated.ts';
+export { roleColors } from './role-colors.generated.ts';

--- a/packages/design-tokens/src/role-colors.generated.ts
+++ b/packages/design-tokens/src/role-colors.generated.ts
@@ -1,4 +1,5 @@
 // Generated from packages/design-tokens/src/theme.css. Do not edit by hand.
+// Run `pnpm --filter @world-history-map/design-tokens run build` to regenerate.
 export const roleColors = {
   selected: 'oklch(0.65 0.22 15)',
   loading: 'oklch(0.78 0.14 165)',

--- a/packages/design-tokens/src/role-colors.generated.ts
+++ b/packages/design-tokens/src/role-colors.generated.ts
@@ -1,0 +1,10 @@
+// Generated from packages/design-tokens/src/theme.css. Do not edit by hand.
+export const roleColors = {
+  selected: 'oklch(0.65 0.22 15)',
+  loading: 'oklch(0.78 0.14 165)',
+  warn: 'oklch(0.78 0.16 75)',
+  error: 'oklch(0.65 0.22 27)',
+  focus: 'oklch(0.55 0.18 250)',
+} as const;
+
+export type RoleColorKey = keyof typeof roleColors;

--- a/packages/design-tokens/src/role-colors.generated.ts
+++ b/packages/design-tokens/src/role-colors.generated.ts
@@ -1,11 +1,11 @@
 // Generated from packages/design-tokens/src/theme.css. Do not edit by hand.
 // Run `pnpm --filter @world-history-map/design-tokens run build` to regenerate.
 export const roleColors = {
-  selected: 'oklch(0.65 0.22 15)',
-  loading: 'oklch(0.78 0.14 165)',
-  warn: 'oklch(0.78 0.16 75)',
-  error: 'oklch(0.65 0.22 27)',
-  focus: 'oklch(0.55 0.18 250)',
+  selected: '#f73d62',
+  loading: '#49d3a1',
+  warn: '#f2a618',
+  error: '#f9423d',
+  focus: '#0072d5',
 } as const;
 
 export type RoleColorKey = keyof typeof roleColors;

--- a/packages/design-tokens/src/theme.css
+++ b/packages/design-tokens/src/theme.css
@@ -19,7 +19,7 @@
 
   --color-surface-base: oklch(0.16 0.01 250);
   --color-surface-panel: oklch(0.30 0.01 250 / 0.95);
-  --color-surface-raise: oklch(1 0 0 / 0.14);
+  --color-surface-raised: oklch(1 0 0 / 0.14);
   --color-surface-border: oklch(0.40 0.01 250);
 
   --color-text-primary: oklch(1 0 0);

--- a/packages/design-tokens/src/theme.css
+++ b/packages/design-tokens/src/theme.css
@@ -1,0 +1,29 @@
+@theme {
+  --color-primary-50: oklch(0.97 0.01 250);
+  --color-primary-100: oklch(0.93 0.03 250);
+  --color-primary-200: oklch(0.86 0.06 250);
+  --color-primary-300: oklch(0.76 0.10 250);
+  --color-primary-400: oklch(0.64 0.15 250);
+  --color-primary-500: oklch(0.55 0.18 250);
+  --color-primary-600: oklch(0.47 0.18 250);
+  --color-primary-700: oklch(0.40 0.16 250);
+  --color-primary-800: oklch(0.34 0.12 250);
+  --color-primary-900: oklch(0.28 0.09 250);
+  --color-primary-950: oklch(0.20 0.06 250);
+
+  --color-role-selected: oklch(0.65 0.22 15);
+  --color-role-loading: oklch(0.78 0.14 165);
+  --color-role-warn: oklch(0.78 0.16 75);
+  --color-role-error: oklch(0.65 0.22 27);
+  --color-role-focus: oklch(0.55 0.18 250);
+
+  --color-surface-base: oklch(0.16 0.01 250);
+  --color-surface-panel: oklch(0.30 0.01 250 / 0.95);
+  --color-surface-raise: oklch(1 0 0 / 0.14);
+  --color-surface-border: oklch(0.40 0.01 250);
+
+  --color-text-primary: oklch(1 0 0);
+  --color-text-secondary: oklch(0.87 0 0);
+  --color-text-tertiary: oklch(0.71 0 0);
+  --color-text-quiet: oklch(0.55 0 0);
+}

--- a/packages/design-tokens/tests/role-colors-builder.test.ts
+++ b/packages/design-tokens/tests/role-colors-builder.test.ts
@@ -1,0 +1,107 @@
+import { promises as fs } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import {
+  extractRoleColors,
+  RoleColorsBuilder,
+  toTypeScriptSource,
+} from '../src/build/role-colors-builder.ts';
+
+const SAMPLE_CSS = `
+@theme {
+  --color-role-selected: oklch(0.65 0.22 15);
+  --color-role-loading: oklch(0.78 0.14 165);
+  --color-role-warn: oklch(0.78 0.16 75);
+  --color-role-error: oklch(0.65 0.22 27);
+  --color-role-focus: oklch(0.55 0.18 250);
+}
+`;
+
+describe('extractRoleColors', () => {
+  it('extracts all --color-role-* values from CSS', () => {
+    const colors = extractRoleColors(SAMPLE_CSS);
+    expect(colors).toEqual({
+      selected: 'oklch(0.65 0.22 15)',
+      loading: 'oklch(0.78 0.14 165)',
+      warn: 'oklch(0.78 0.16 75)',
+      error: 'oklch(0.65 0.22 27)',
+      focus: 'oklch(0.55 0.18 250)',
+    });
+  });
+
+  it('ignores non-role color variables', () => {
+    const css = `
+      --color-primary-50: oklch(0.97 0.01 250);
+      --color-role-selected: oklch(0.65 0.22 15);
+    `;
+    const colors = extractRoleColors(css);
+    expect(Object.keys(colors)).toEqual(['selected']);
+  });
+
+  it('throws when no --color-role-* definitions are found', () => {
+    expect(() => extractRoleColors('--color-primary-50: red;')).toThrow(
+      'No --color-role-* definitions found in CSS',
+    );
+  });
+});
+
+describe('toTypeScriptSource', () => {
+  it('generates valid TypeScript source with as const', () => {
+    const source = toTypeScriptSource({ selected: 'oklch(0.65 0.22 15)' });
+    expect(source).toContain("selected: 'oklch(0.65 0.22 15)'");
+    expect(source).toContain('} as const;');
+    expect(source).toContain('export type RoleColorKey');
+  });
+});
+
+describe('RoleColorsBuilder', () => {
+  let tmpDir: string;
+  let cssPath: string;
+  let outputPath: string;
+
+  beforeAll(async () => {
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'design-tokens-test-'));
+    cssPath = path.join(tmpDir, 'theme.css');
+    outputPath = path.join(tmpDir, 'role-colors.generated.ts');
+    await fs.writeFile(cssPath, SAMPLE_CSS);
+  });
+
+  afterAll(async () => {
+    await fs.rm(tmpDir, { recursive: true, force: true });
+  });
+
+  it('generateSource returns TypeScript source containing all 5 role colors', async () => {
+    const builder = new RoleColorsBuilder(cssPath, outputPath);
+    const source = await builder.generateSource();
+    expect(source).toContain("selected: 'oklch(0.65 0.22 15)'");
+    expect(source).toContain("loading: 'oklch(0.78 0.14 165)'");
+    expect(source).toContain("warn: 'oklch(0.78 0.16 75)'");
+    expect(source).toContain("error: 'oklch(0.65 0.22 27)'");
+    expect(source).toContain("focus: 'oklch(0.55 0.18 250)'");
+  });
+
+  it('isFresh returns false when output file does not exist', async () => {
+    const builder = new RoleColorsBuilder(cssPath, outputPath);
+    expect(await builder.isFresh()).toBe(false);
+  });
+
+  it('isFresh returns true after writing the generated source', async () => {
+    const builder = new RoleColorsBuilder(cssPath, outputPath);
+    const source = await builder.generateSource();
+    await fs.writeFile(outputPath, source);
+    expect(await builder.isFresh()).toBe(true);
+  });
+
+  it('isFresh returns false when CSS is modified after generation', async () => {
+    const builder = new RoleColorsBuilder(cssPath, outputPath);
+    const source = await builder.generateSource();
+    await fs.writeFile(outputPath, source);
+
+    await fs.writeFile(cssPath, SAMPLE_CSS.replace('oklch(0.65 0.22 15)', 'oklch(0.70 0.25 20)'));
+
+    expect(await builder.isFresh()).toBe(false);
+
+    await fs.writeFile(cssPath, SAMPLE_CSS);
+  });
+});

--- a/packages/design-tokens/tests/role-colors-builder.test.ts
+++ b/packages/design-tokens/tests/role-colors-builder.test.ts
@@ -56,19 +56,19 @@ describe('toTypeScriptSource', () => {
 });
 
 describe('RoleColorsBuilder', () => {
-  let tmpDir: string;
+  let temporaryDir: string;
   let cssPath: string;
   let outputPath: string;
 
   beforeAll(async () => {
-    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'design-tokens-test-'));
-    cssPath = path.join(tmpDir, 'theme.css');
-    outputPath = path.join(tmpDir, 'role-colors.generated.ts');
+    temporaryDir = await fs.mkdtemp(path.join(os.tmpdir(), 'design-tokens-test-'));
+    cssPath = path.join(temporaryDir, 'theme.css');
+    outputPath = path.join(temporaryDir, 'role-colors.generated.ts');
     await fs.writeFile(cssPath, SAMPLE_CSS);
   });
 
   afterAll(async () => {
-    await fs.rm(tmpDir, { recursive: true, force: true });
+    await fs.rm(temporaryDir, { recursive: true, force: true });
   });
 
   it('generateSource returns TypeScript source containing all 5 role colors', async () => {

--- a/packages/design-tokens/tests/role-colors-builder.test.ts
+++ b/packages/design-tokens/tests/role-colors-builder.test.ts
@@ -72,7 +72,7 @@ describe('RoleColorsBuilder', () => {
   });
 
   it('generateSource returns TypeScript source containing all 5 role colors', async () => {
-    const builder = new RoleColorsBuilder(cssPath, outputPath);
+    const builder = new RoleColorsBuilder({ cssPath, outputPath });
     const source = await builder.generateSource();
     expect(source).toContain("selected: 'oklch(0.65 0.22 15)'");
     expect(source).toContain("loading: 'oklch(0.78 0.14 165)'");
@@ -82,19 +82,19 @@ describe('RoleColorsBuilder', () => {
   });
 
   it('isFresh returns false when output file does not exist', async () => {
-    const builder = new RoleColorsBuilder(cssPath, outputPath);
+    const builder = new RoleColorsBuilder({ cssPath, outputPath });
     expect(await builder.isFresh()).toBe(false);
   });
 
   it('isFresh returns true after writing the generated source', async () => {
-    const builder = new RoleColorsBuilder(cssPath, outputPath);
+    const builder = new RoleColorsBuilder({ cssPath, outputPath });
     const source = await builder.generateSource();
     await fs.writeFile(outputPath, source);
     expect(await builder.isFresh()).toBe(true);
   });
 
   it('isFresh returns false when CSS is modified after generation', async () => {
-    const builder = new RoleColorsBuilder(cssPath, outputPath);
+    const builder = new RoleColorsBuilder({ cssPath, outputPath });
     const source = await builder.generateSource();
     await fs.writeFile(outputPath, source);
 

--- a/packages/design-tokens/tests/role-colors-builder.test.ts
+++ b/packages/design-tokens/tests/role-colors-builder.test.ts
@@ -47,9 +47,9 @@ describe('extractRoleColors', () => {
 });
 
 describe('toTypeScriptSource', () => {
-  it('generates valid TypeScript source with as const', () => {
+  it('generates valid TypeScript source with as const and hex-converted values', () => {
     const source = toTypeScriptSource({ selected: 'oklch(0.65 0.22 15)' });
-    expect(source).toContain("selected: 'oklch(0.65 0.22 15)'");
+    expect(source).toContain("selected: '#f73d62'");
     expect(source).toContain('} as const;');
     expect(source).toContain('export type RoleColorKey');
   });
@@ -71,14 +71,14 @@ describe('RoleColorsBuilder', () => {
     await fs.rm(temporaryDir, { recursive: true, force: true });
   });
 
-  it('generateSource returns TypeScript source containing all 5 role colors', async () => {
+  it('generateSource returns TypeScript source containing all 5 role colors as hex', async () => {
     const builder = new RoleColorsBuilder({ cssPath, outputPath });
     const source = await builder.generateSource();
-    expect(source).toContain("selected: 'oklch(0.65 0.22 15)'");
-    expect(source).toContain("loading: 'oklch(0.78 0.14 165)'");
-    expect(source).toContain("warn: 'oklch(0.78 0.16 75)'");
-    expect(source).toContain("error: 'oklch(0.65 0.22 27)'");
-    expect(source).toContain("focus: 'oklch(0.55 0.18 250)'");
+    expect(source).toContain("selected: '#f73d62'");
+    expect(source).toContain("loading: '#49d3a1'");
+    expect(source).toContain("warn: '#f2a618'");
+    expect(source).toContain("error: '#f9423d'");
+    expect(source).toContain("focus: '#0072d5'");
   });
 
   it('isFresh returns false when output file does not exist', async () => {

--- a/packages/design-tokens/tsconfig.json
+++ b/packages/design-tokens/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "files": [],
+  "references": [{ "path": "./tsconfig.tokens.json" }],
+  "compilerOptions": {
+    "baseUrl": ".",
+    "paths": { "@/*": ["./src/*"] }
+  }
+}

--- a/packages/design-tokens/tsconfig.tokens.json
+++ b/packages/design-tokens/tsconfig.tokens.json
@@ -1,0 +1,34 @@
+{
+  "compilerOptions": {
+    "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.tokens.tsbuildinfo",
+    "target": "ES2023",
+    "lib": ["ES2023"],
+    "module": "ESNext",
+    "types": ["node"],
+    "skipLibCheck": true,
+
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "verbatimModuleSyntax": true,
+    "moduleDetection": "force",
+    "noEmit": true,
+
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "erasableSyntaxOnly": true,
+    "noFallthroughCasesInSwitch": true,
+    "noUncheckedSideEffectImports": true,
+
+    "noImplicitReturns": true,
+    "noPropertyAccessFromIndexSignature": true,
+    "noUncheckedIndexedAccess": true,
+    "exactOptionalPropertyTypes": true,
+
+    "paths": {
+      "@/*": ["./src/*"]
+    }
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["src/**/*.test.*", "src/**/*.spec.*"]
+}

--- a/packages/design-tokens/vitest.config.ts
+++ b/packages/design-tokens/vitest.config.ts
@@ -1,0 +1,15 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: 'node',
+    passWithNoTests: true,
+    include: ['tests/**/*.{test,spec}.ts'],
+    coverage: {
+      provider: 'v8',
+      include: ['src/**/*.ts'],
+      exclude: ['src/**/*.d.ts', 'src/**/*.{test,spec}.ts', 'src/build/**/*.ts'],
+    },
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,6 +23,9 @@ importers:
 
   apps/frontend:
     dependencies:
+      '@world-history-map/design-tokens':
+        specifier: workspace:*
+        version: link:../../packages/design-tokens
       '@world-history-map/tiles':
         specifier: workspace:*
         version: link:../../packages/tiles
@@ -135,6 +138,21 @@ importers:
       wrangler:
         specifier: ^4.87.0
         version: 4.87.0(@cloudflare/workers-types@4.20260502.1)
+
+  packages/design-tokens:
+    devDependencies:
+      '@types/node':
+        specifier: ^25.6.0
+        version: 25.6.0
+      '@vitest/coverage-v8':
+        specifier: ^4.1.5
+        version: 4.1.5(vitest@4.1.5)
+      tsx:
+        specifier: ^4.19.4
+        version: 4.21.0
+      vitest:
+        specifier: ^4.1.5
+        version: 4.1.5(@types/node@25.6.0)(@vitest/coverage-v8@4.1.5)(jsdom@29.1.1)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.2))
 
   packages/tiles:
     devDependencies:

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,6 +3,7 @@
   "references": [
     { "path": "./apps/frontend" },
     { "path": "./apps/pipeline" },
+    { "path": "./packages/design-tokens" },
     { "path": "./packages/tiles" },
     { "path": "./scripts/tiles-gc" }
   ]


### PR DESCRIPTION
## 概要

close #236

`index.css` の `@theme` ブロックと `territory-style-constants.ts` の `HIGHLIGHT_COLOR` が同一色を二か所に手書きしていた問題を解消しました。新しい workspace パッケージ `@world-history-map/design-tokens` を追加し、`theme.css` を Single Source of Truth として CSS と TS を自動同期するビルドステップを導入しています。

### 背景

- MapLibre の paint props は CSS 変数を参照できないため、TS 定数が別途必要でした
- そのため `--color-role-selected`（CSS）と `HIGHLIGHT_COLOR`（TS）が同一色の二重定義になっており、片方を変更したときにもう一方を更新し忘れるリスクがありました
- 将来的にロールカラー以外のデザイントークンが増えても対応できる基盤が欲しかったという背景もあります

### 変更内容

**`packages/design-tokens/` を新規追加**

- `src/theme.css`: `index.css` から `@theme` ブロックを移動。CSS の唯一の定義場所になります
- `src/build/role-colors-builder.ts`: `--color-role-*` を正規表現で抽出し、`as const` の TS ソースを生成するビルダークラス
- `src/build/cli.ts`: `pnpm build` / `pnpm build:check` のエントリポイント。`--check` モードで生成物のドリフトを検出します
- `src/role-colors.generated.ts`: 生成物（コミット済み）。`packages/tiles/src/manifest.ts` と同じパターンです

**既存ファイルの変更**

- `index.css`: `@theme` ブロックを `@import "@world-history-map/design-tokens/theme.css"` に置き換えました
- `territory-style-constants.ts`: `HIGHLIGHT_COLOR = '#f43f5e'` → `HIGHLIGHT_COLOR = roleColors.selected` に変更し、手動同期を示すコメントを削除しました
- `package.json` / `tsconfig.json`: `predev` / `prebuild` フックと project references を設定しました
- `ci.yml`: `verify-generated` ジョブを追加し、`build:check` で PR ごとにドリフトを自動検出します。`packages/tiles` のドリフト検出もこのジョブに統合しています

## 動作確認

- [ ] `pnpm verify` が通ること
- [ ] `pnpm test` が通ること（design-tokens の unit テスト 8 件を含む）
- [ ] `pnpm dev` で地図が表示され、領土クリック時のハイライトが赤系（rose-500 相当）で表示されること
- [ ] `theme.css` の色を変更後に `pnpm --filter @world-history-map/design-tokens run build:check` が exit 1 を返すこと

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
