### PR TITLE
chore(biome): use local schema path to avoid manual version updates

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.4.14/schema.json",
+  "$schema": "./node_modules/@biomejs/biome/configuration_schema.json",
   "vcs": {
     "enabled": true,
     "clientKind": "git",


### PR DESCRIPTION
## 概要

Biome の `$schema` を versioned URL から `node_modules` への相対パスに変更しました。

### 背景

- バージョンアップのたびに `biome.json` の URL 内のバージョン番号を手動で書き換える必要があり、面倒でした。

### 変更内容

- `$schema` の値を `https://biomejs.dev/schemas/X.Y.Z/schema.json` から `./node_modules/@biomejs/biome/configuration_schema.json` に変更しました。
- これにより `pnpm up @biomejs/biome` でバージョンを上げるだけでスキーマも自動更新されます。IDE のスキーマ補完も従来通り動作します。

## 動作確認

### 自動確認済み
- [x] `pnpm verify`（typecheck + biome check）が通ることを確認しました。

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
