### PR TITLE
refactor(territory): extract TerritoryName value object and repository pattern

### DIFF
--- a/apps/frontend/src/domain/territory/description-loader.ts
+++ b/apps/frontend/src/domain/territory/description-loader.ts
@@ -1,58 +1,40 @@
-import { CachedFetcher } from '../../lib/cached-fetcher';
 import type { HistoricalYear } from '../year/historical-year';
+import {
+  type DescriptionBundleSource,
+  HttpTerritoryDescriptionRepository,
+} from './http-territory-description-repository';
+import { TerritoryName } from './territory-name';
 import type { TerritoryDescription, YearDescriptionBundle } from './types';
 
-const yearFetchers = new Map<HistoricalYear, CachedFetcher<YearDescriptionBundle | null>>();
+class HttpDescriptionBundleSource implements DescriptionBundleSource {
+  async fetch(year: HistoricalYear): Promise<YearDescriptionBundle | null> {
+    const response = await fetch(`/data/descriptions/${year}.json`);
 
-function getYearFetcher(year: HistoricalYear): CachedFetcher<YearDescriptionBundle | null> {
-  let fetcher = yearFetchers.get(year);
-  if (fetcher) return fetcher;
+    if (!response.ok) {
+      if (response.status === 404) return null;
+      throw new Error(`Failed to fetch description bundle: ${response.status}`);
+    }
 
-  fetcher = new CachedFetcher<YearDescriptionBundle | null>({
-    async fetch() {
-      const response = await fetch(`/data/descriptions/${year}.json`);
+    const contentType = response.headers.get('content-type');
+    if (!contentType?.includes('application/json')) return null;
 
-      if (!response.ok) {
-        if (response.status === 404) return null;
-        throw new Error(`Failed to fetch description bundle: ${response.status}`);
-      }
-
-      const contentType = response.headers.get('content-type');
-      if (!contentType?.includes('application/json')) return null;
-
-      return response.json() as Promise<YearDescriptionBundle>;
-    },
-  });
-
-  yearFetchers.set(year, fetcher);
-  return fetcher;
+    return response.json() as Promise<YearDescriptionBundle>;
+  }
 }
 
-function toKebabCase(name: string): string {
-  return name
-    .toLowerCase()
-    .replace(/\s+/g, '-')
-    .replace(/[^a-z0-9-]/g, '');
-}
+const repository = new HttpTerritoryDescriptionRepository(new HttpDescriptionBundleSource());
 
 export function prefetchYearDescriptions(year: HistoricalYear): void {
-  getYearFetcher(year)
-    .load()
-    .catch(() => {});
+  repository.prefetch(year);
 }
 
 export function clearDescriptionCache(): void {
-  yearFetchers.clear();
+  repository.clearCache();
 }
 
 export async function loadTerritoryDescription(
   territoryName: string,
   year: HistoricalYear,
 ): Promise<TerritoryDescription | null> {
-  const bundle = await getYearFetcher(year).load();
-
-  if (!bundle) return null;
-
-  const key = toKebabCase(territoryName);
-  return bundle[key] ?? null;
+  return repository.load(new TerritoryName(territoryName), year);
 }

--- a/apps/frontend/src/domain/territory/http-territory-description-repository.test.ts
+++ b/apps/frontend/src/domain/territory/http-territory-description-repository.test.ts
@@ -1,0 +1,99 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { createHistoricalYear } from '../year/historical-year';
+import type { DescriptionBundleSource } from './http-territory-description-repository';
+import { HttpTerritoryDescriptionRepository } from './http-territory-description-repository';
+import { TerritoryName } from './territory-name';
+import type { YearDescriptionBundle } from './types';
+
+const bundle1650: YearDescriptionBundle = {
+  france: { name: 'フランス王国' },
+  england: { name: 'イングランド' },
+  'england-and-ireland': { name: 'イングランドとアイルランド' },
+};
+
+const bundle1700: YearDescriptionBundle = {
+  france: { name: 'フランス王国（絶対王政期）' },
+};
+
+function createMockSource(bundles: Record<number, YearDescriptionBundle | null>) {
+  return {
+    fetch: vi.fn(async (year: number) => bundles[year] ?? null),
+  } satisfies DescriptionBundleSource;
+}
+
+describe('HttpTerritoryDescriptionRepository', () => {
+  let source: ReturnType<typeof createMockSource>;
+  let repository: HttpTerritoryDescriptionRepository;
+
+  beforeEach(() => {
+    source = createMockSource({ 1650: bundle1650, 1700: bundle1700 });
+    repository = new HttpTerritoryDescriptionRepository(source);
+  });
+
+  describe('load', () => {
+    it('returns the description for a matching territory', async () => {
+      const result = await repository.load(new TerritoryName('France'), createHistoricalYear(1650));
+      expect(result).toEqual(bundle1650['france']);
+    });
+
+    it('converts territory name to kebab-case for bundle lookup', async () => {
+      const result = await repository.load(
+        new TerritoryName('England and Ireland'),
+        createHistoricalYear(1650),
+      );
+      expect(result).toEqual(bundle1650['england-and-ireland']);
+    });
+
+    it('returns null when territory is not in the bundle', async () => {
+      const result = await repository.load(
+        new TerritoryName('UnknownTerritory'),
+        createHistoricalYear(1650),
+      );
+      expect(result).toBeNull();
+    });
+
+    it('returns null when bundle is null (year not found)', async () => {
+      const result = await repository.load(new TerritoryName('France'), createHistoricalYear(9999));
+      expect(result).toBeNull();
+    });
+
+    it('fetches the bundle only once per year across multiple loads', async () => {
+      await repository.load(new TerritoryName('France'), createHistoricalYear(1650));
+      await repository.load(new TerritoryName('England'), createHistoricalYear(1650));
+      expect(source.fetch).toHaveBeenCalledTimes(1);
+    });
+
+    it('fetches separately for different years', async () => {
+      await repository.load(new TerritoryName('France'), createHistoricalYear(1650));
+      await repository.load(new TerritoryName('France'), createHistoricalYear(1700));
+      expect(source.fetch).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe('prefetch', () => {
+    it('triggers a fetch so subsequent load uses cache', async () => {
+      repository.prefetch(createHistoricalYear(1650));
+      await vi.waitFor(() => expect(source.fetch).toHaveBeenCalledTimes(1));
+
+      await repository.load(new TerritoryName('France'), createHistoricalYear(1650));
+      expect(source.fetch).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not throw on source error', () => {
+      source.fetch.mockRejectedValueOnce(new Error('Network error'));
+      expect(() => repository.prefetch(createHistoricalYear(1650))).not.toThrow();
+    });
+  });
+
+  describe('clearCache', () => {
+    it('causes next load to re-fetch from source', async () => {
+      await repository.load(new TerritoryName('France'), createHistoricalYear(1650));
+      expect(source.fetch).toHaveBeenCalledTimes(1);
+
+      repository.clearCache();
+
+      await repository.load(new TerritoryName('France'), createHistoricalYear(1650));
+      expect(source.fetch).toHaveBeenCalledTimes(2);
+    });
+  });
+});

--- a/apps/frontend/src/domain/territory/http-territory-description-repository.ts
+++ b/apps/frontend/src/domain/territory/http-territory-description-repository.ts
@@ -1,0 +1,48 @@
+import { CachedFetcher } from '../../lib/cached-fetcher';
+import type { HistoricalYear } from '../year/historical-year';
+import type { TerritoryDescriptionRepository } from './territory-description-repository';
+import type { TerritoryName } from './territory-name';
+import type { TerritoryDescription, YearDescriptionBundle } from './types';
+
+export interface DescriptionBundleSource {
+  fetch(year: HistoricalYear): Promise<YearDescriptionBundle | null>;
+}
+
+export class HttpTerritoryDescriptionRepository implements TerritoryDescriptionRepository {
+  private readonly fetchers = new Map<
+    HistoricalYear,
+    CachedFetcher<YearDescriptionBundle | null>
+  >();
+  private readonly source: DescriptionBundleSource;
+
+  constructor(source: DescriptionBundleSource) {
+    this.source = source;
+  }
+
+  async load(name: TerritoryName, year: HistoricalYear): Promise<TerritoryDescription | null> {
+    const bundle = await this.fetcherFor(year).load();
+    if (!bundle) return null;
+    return bundle[name.toLookupKey()] ?? null;
+  }
+
+  prefetch(year: HistoricalYear): void {
+    this.fetcherFor(year)
+      .load()
+      .catch(() => {});
+  }
+
+  clearCache(): void {
+    this.fetchers.clear();
+  }
+
+  private fetcherFor(year: HistoricalYear): CachedFetcher<YearDescriptionBundle | null> {
+    let fetcher = this.fetchers.get(year);
+    if (fetcher) return fetcher;
+
+    fetcher = new CachedFetcher<YearDescriptionBundle | null>({
+      fetch: () => this.source.fetch(year),
+    });
+    this.fetchers.set(year, fetcher);
+    return fetcher;
+  }
+}

--- a/apps/frontend/src/domain/territory/territory-description-repository.ts
+++ b/apps/frontend/src/domain/territory/territory-description-repository.ts
@@ -1,0 +1,9 @@
+import type { HistoricalYear } from '../year/historical-year';
+import type { TerritoryName } from './territory-name';
+import type { TerritoryDescription } from './types';
+
+export interface TerritoryDescriptionRepository {
+  load(name: TerritoryName, year: HistoricalYear): Promise<TerritoryDescription | null>;
+  prefetch(year: HistoricalYear): void;
+  clearCache(): void;
+}

--- a/apps/frontend/src/domain/territory/territory-name.test.ts
+++ b/apps/frontend/src/domain/territory/territory-name.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest';
+import { TerritoryName } from './territory-name';
+
+describe('TerritoryName', () => {
+  describe('toLookupKey', () => {
+    it('converts to lowercase', () => {
+      expect(new TerritoryName('France').toLookupKey()).toBe('france');
+    });
+
+    it('replaces spaces with hyphens', () => {
+      expect(new TerritoryName('England and Ireland').toLookupKey()).toBe('england-and-ireland');
+    });
+
+    it('removes non-alphanumeric characters except hyphens', () => {
+      expect(new TerritoryName("Côte d'Ivoire").toLookupKey()).toBe('cte-divoire');
+    });
+
+    it('collapses multiple spaces into a single hyphen', () => {
+      expect(new TerritoryName('Holy  Roman  Empire').toLookupKey()).toBe('holy-roman-empire');
+    });
+
+    it('preserves existing hyphens', () => {
+      expect(new TerritoryName('Bosnia-Herzegovina').toLookupKey()).toBe('bosnia-herzegovina');
+    });
+  });
+});

--- a/apps/frontend/src/domain/territory/territory-name.ts
+++ b/apps/frontend/src/domain/territory/territory-name.ts
@@ -1,0 +1,14 @@
+export class TerritoryName {
+  private readonly value: string;
+
+  constructor(value: string) {
+    this.value = value;
+  }
+
+  toLookupKey(): string {
+    return this.value
+      .toLowerCase()
+      .replace(/\s+/g, '-')
+      .replace(/[^a-z0-9-]/g, '');
+  }
+}


### PR DESCRIPTION
## 概要

close #239

`description-loader.ts` に混在していたモジュールスコープの可変 Map・HTTP fetch のハードコード・kebab-case 変換ロジックを、それぞれ適切なクラスと interface に分離しました。

### 背景

- モジュールスコープの `yearFetchers: Map` を複数の関数が直接書き換えており、テスト間で状態が干渉するリスクがありました
- `fetch('/data/descriptions/${year}.json')` がハードコードされており、テスト時に差し替えが不可能でした
- kebab-case 変換ロジックが private 関数として description-loader に埋まっており、パイプライン側など他の箇所から再利用できませんでした

### 変更内容

- `TerritoryName` 値オブジェクトを導入し、kebab-case 変換ルールを `toLookupKey()` メソッドとして集約しました
- `TerritoryDescriptionRepository` interface と `HttpTerritoryDescriptionRepository` クラスを導入しました。コンストラクタで `DescriptionBundleSource` interface（HTTP fetch の抽象）を受け取るため、テストではモック実装を注入できます
- モジュールスコープの可変 Map をクラスフィールドにカプセル化しました。インスタンスを作り直すだけでテスト間の状態干渉を排除できます
- `description-loader.ts` は既存の公開 API（`prefetchYearDescriptions` / `clearDescriptionCache` / `loadTerritoryDescription`）を維持する薄いファサードになりました。呼び出し元への変更はありません

## 動作確認

### 自動確認済み

- [x] `pnpm test` が全件パス（278 tests）
- [x] `pnpm typecheck` が通る
- [x] `biome check` が通る

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
