### PR TITLE
feat(modal): redesign about modal with unified section layout

### DIFF
--- a/apps/frontend/public/LICENSE-data.txt
+++ b/apps/frontend/public/LICENSE-data.txt
@@ -29,6 +29,12 @@ Attribution
 When using this data, please credit:
 "Map data based on historical-basemaps by André Ourednik (GPL-3.0)"
 
+Changes Made to Original Data
+------------------------------
+The original GeoJSON data was processed for web use: converted to PMTiles
+format, properties reduced, geometries simplified, and territory
+descriptions added from an external source.
+
 Contact
 -------
 For questions about the original data, please visit:

--- a/apps/frontend/src/components/control-bar/control-bar.test.tsx
+++ b/apps/frontend/src/components/control-bar/control-bar.test.tsx
@@ -31,11 +31,6 @@ describe('ControlBar', () => {
     expect(screen.getByTestId('license-link')).toBeInTheDocument();
   });
 
-  it('renders GitHub link', () => {
-    renderWithProvider(<ControlBar {...defaultProps} />);
-    expect(screen.getByTestId('github-link')).toBeInTheDocument();
-  });
-
   it('calls onOpenLicense when license button is clicked', () => {
     renderWithProvider(<ControlBar {...defaultProps} />);
     fireEvent.click(screen.getByTestId('license-link'));
@@ -45,12 +40,5 @@ describe('ControlBar', () => {
   it('passes projection to ProjectionToggle', () => {
     renderWithProvider(<ControlBar {...defaultProps} />);
     fireEvent.click(screen.getByTestId('projection-toggle'));
-  });
-
-  it('has correct GitHub link href', () => {
-    renderWithProvider(<ControlBar {...defaultProps} />);
-    const link = screen.getByTestId('github-link');
-    expect(link).toHaveAttribute('href', 'https://github.com/akihiro-tj/world-history-map');
-    expect(link).toHaveAttribute('target', '_blank');
   });
 });

--- a/apps/frontend/src/components/control-bar/control-bar.tsx
+++ b/apps/frontend/src/components/control-bar/control-bar.tsx
@@ -38,29 +38,6 @@ export function ControlBar({ onOpenLicense }: ControlBarProps) {
         </svg>
         <span className="sr-only">このサイトについて</span>
       </button>
-      <a
-        href="https://github.com/akihiro-tj/world-history-map"
-        target="_blank"
-        rel="noopener noreferrer"
-        data-testid="github-link"
-        className="rounded-lg bg-gray-700/95 p-3 text-white/60 shadow-lg backdrop-blur-sm transition-colors hover:text-white"
-      >
-        <svg
-          className="h-6 w-6"
-          viewBox="0 0 24 24"
-          fill="none"
-          stroke="currentColor"
-          strokeWidth="1.5"
-          aria-hidden="true"
-        >
-          <path
-            strokeLinecap="round"
-            strokeLinejoin="round"
-            d="M17.25 6.75 22.5 12l-5.25 5.25m-10.5 0L1.5 12l5.25-5.25m7.5-3-4.5 16.5"
-          />
-        </svg>
-        <span className="sr-only">ソースコードを見る</span>
-      </a>
     </div>
   );
 }

--- a/apps/frontend/src/components/legal/license-disclaimer.test.tsx
+++ b/apps/frontend/src/components/legal/license-disclaimer.test.tsx
@@ -32,7 +32,7 @@ describe('LicenseDisclaimer', () => {
 
       const title = screen.getByRole('heading', { level: 2 });
       expect(title).toBeInTheDocument();
-      expect(title).toHaveTextContent(/ライセンス|免責事項/);
+      expect(title).toHaveTextContent('このサイトについて');
     });
 
     it('renders close button', () => {
@@ -53,38 +53,31 @@ describe('LicenseDisclaimer', () => {
     it('displays historical-basemaps attribution', () => {
       render(<LicenseDisclaimer {...defaultProps} />);
 
-      expect(screen.getByText(/historical-basemaps/)).toBeInTheDocument();
+      expect(screen.getAllByText(/historical-basemaps/)[0]).toBeInTheDocument();
     });
 
-    it('displays link to original repository', () => {
+    it('displays links to original repository', () => {
       render(<LicenseDisclaimer {...defaultProps} />);
 
-      const link = screen.getByRole('link', { name: /historical-basemaps/i });
-      expect(link).toBeInTheDocument();
-      expect(link).toHaveAttribute('href', 'https://github.com/aourednik/historical-basemaps');
-    });
-  });
-
-  describe('Disclaimer Content', () => {
-    it('displays data accuracy disclaimer section', () => {
-      render(<LicenseDisclaimer {...defaultProps} />);
-
-      const dataDisclaimer = screen.getByTestId('data-disclaimer');
-      expect(dataDisclaimer).toBeInTheDocument();
+      const links = screen.getAllByRole('link', { name: /historical-basemaps/i });
+      expect(links).toHaveLength(2);
+      for (const link of links) {
+        expect(link).toHaveAttribute('href', 'https://github.com/aourednik/historical-basemaps');
+      }
     });
 
-    it('displays historical borders disclaimer section', () => {
+    it('displays link to license full text', () => {
       render(<LicenseDisclaimer {...defaultProps} />);
 
-      const bordersDisclaimer = screen.getByTestId('borders-disclaimer');
-      expect(bordersDisclaimer).toBeInTheDocument();
+      const link = screen.getByRole('link', { name: /ライセンス全文/i });
+      expect(link).toHaveAttribute('href', '/LICENSE-data.txt');
     });
 
-    it('displays disputed territories disclaimer section', () => {
+    it('displays link to source code repository', () => {
       render(<LicenseDisclaimer {...defaultProps} />);
 
-      const disputedDisclaimer = screen.getByTestId('disputed-disclaimer');
-      expect(disputedDisclaimer).toBeInTheDocument();
+      const link = screen.getByRole('link', { name: /GitHub/i });
+      expect(link).toHaveAttribute('href', 'https://github.com/akihiro-tj/world-history-map');
     });
   });
 

--- a/apps/frontend/src/components/legal/license-disclaimer.tsx
+++ b/apps/frontend/src/components/legal/license-disclaimer.tsx
@@ -87,7 +87,7 @@ export function LicenseDisclaimer({ isOpen, onClose }: LicenseDisclaimerProps) {
           <section>
             <h3 className="mb-3 text-base font-semibold text-white">ライセンス</h3>
             <p className="text-sm leading-relaxed text-gray-300">
-              本サイトで使用している地図データは{' '}
+              本サイトで使用している地図データは André Ourednik 氏による{' '}
               <a
                 href="https://github.com/aourednik/historical-basemaps"
                 target="_blank"

--- a/apps/frontend/src/components/legal/license-disclaimer.tsx
+++ b/apps/frontend/src/components/legal/license-disclaimer.tsx
@@ -27,7 +27,6 @@ export function LicenseDisclaimer({ isOpen, onClose }: LicenseDisclaimerProps) {
 
   const handleDialogClick = useCallback(
     (event: React.MouseEvent<HTMLDivElement>) => {
-      // biome-ignore lint/a11y/useKeyWithClickEvents: Keyboard events are handled by the document-level Escape key listener
       if (event.target === event.currentTarget) {
         onClose();
       }

--- a/apps/frontend/src/components/legal/license-disclaimer.tsx
+++ b/apps/frontend/src/components/legal/license-disclaimer.tsx
@@ -8,6 +8,9 @@ export interface LicenseDisclaimerProps {
   onClose: () => void;
 }
 
+const linkClass =
+  'text-blue-400 hover:text-blue-300 underline decoration-blue-400/40 hover:decoration-blue-300 underline-offset-2 transition-colors';
+
 export function LicenseDisclaimer({ isOpen, onClose }: LicenseDisclaimerProps) {
   const modalRef = useRef<HTMLDivElement>(null);
   const closeButtonRef = useRef<HTMLButtonElement>(null);
@@ -24,7 +27,7 @@ export function LicenseDisclaimer({ isOpen, onClose }: LicenseDisclaimerProps) {
 
   const handleDialogClick = useCallback(
     (event: React.MouseEvent<HTMLDivElement>) => {
-      // Close only if clicking directly on the dialog wrapper (backdrop area)
+      // biome-ignore lint/a11y/useKeyWithClickEvents: Keyboard events are handled by the document-level Escape key listener
       if (event.target === event.currentTarget) {
         onClose();
       }
@@ -47,7 +50,6 @@ export function LicenseDisclaimer({ isOpen, onClose }: LicenseDisclaimerProps) {
       className="fixed inset-0 z-50 flex items-center justify-center"
       onClick={handleDialogClick}
     >
-      {/* Backdrop - clicking closes modal */}
       <div
         data-testid="license-modal-backdrop"
         className="absolute inset-0 bg-black/50 backdrop-blur-sm"
@@ -57,98 +59,74 @@ export function LicenseDisclaimer({ isOpen, onClose }: LicenseDisclaimerProps) {
 
       <div
         data-testid="license-modal-content"
-        className="relative z-10 mx-4 max-h-[90vh] w-full max-w-2xl overflow-y-auto rounded-lg bg-gray-700 p-6 shadow-2xl"
+        className="relative z-10 mx-4 max-h-[90vh] w-full max-w-2xl overflow-y-auto rounded-lg bg-gray-700 p-6 shadow-2xl sm:p-8"
       >
-        <div className="mb-6 flex items-center justify-between border-b border-gray-600 pb-4">
+        <div className="mb-7 flex items-start justify-between border-b border-gray-600 pb-4">
           <h2 id="license-disclaimer-title" className="text-xl font-semibold text-white">
-            ライセンス・免責事項
+            このサイトについて
           </h2>
           <CloseButton ref={closeButtonRef} onClick={onClose} aria-label="閉じる" />
         </div>
 
-        <div className="space-y-6">
+        <div className="space-y-8">
           <section>
-            <h3 className="mb-3 text-lg font-medium text-white">ライセンス情報</h3>
-            <div className="rounded-lg bg-gray-600 p-4">
-              <p className="mb-2 text-sm text-gray-200">
-                本アプリケーションで使用している地図データは{' '}
-                <a
-                  href="https://github.com/aourednik/historical-basemaps"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="font-medium text-blue-400 hover:underline"
-                >
-                  historical-basemaps
-                </a>{' '}
-                プロジェクトに基づいています。
-              </p>
-              <p className="text-sm text-gray-200">
-                このデータは{' '}
-                <span className="font-medium text-white">
-                  GNU General Public License v3.0 (GPL-3.0)
-                </span>{' '}
-                の下で提供されています。
-              </p>
-              <p className="mt-2 text-sm text-gray-200">
-                <a
-                  href="/LICENSE-data.txt"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="font-medium text-blue-400 hover:underline"
-                >
-                  ライセンス全文を見る
-                </a>
-              </p>
-            </div>
-          </section>
-
-          <section data-testid="data-disclaimer">
-            <h3 className="mb-3 text-lg font-medium text-white">データの正確性について</h3>
-            <div className="rounded-lg border-l-4 border-yellow-600 bg-yellow-900/30 p-4">
-              <div className="flex">
-                <div className="flex-shrink-0">
-                  <svg
-                    className="h-5 w-5 text-yellow-500"
-                    viewBox="0 0 20 20"
-                    fill="currentColor"
-                    aria-hidden="true"
-                  >
-                    <path
-                      fillRule="evenodd"
-                      d="M8.485 2.495c.673-1.167 2.357-1.167 3.03 0l6.28 10.875c.673 1.167-.17 2.625-1.516 2.625H3.72c-1.347 0-2.189-1.458-1.515-2.625L8.485 2.495zM10 5a.75.75 0 01.75.75v3.5a.75.75 0 01-1.5 0v-3.5A.75.75 0 0110 5zm0 9a1 1 0 100-2 1 1 0 000 2z"
-                      clipRule="evenodd"
-                    />
-                  </svg>
-                </div>
-                <div className="ml-3">
-                  <p className="text-sm text-yellow-300">
-                    本アプリケーションは開発中のプロジェクトであり、表示されるデータは完全または正確でない可能性があります。歴史的な調査や学術的な目的には、複数の信頼できる情報源との照合をお勧めします。
-                  </p>
-                </div>
-              </div>
-            </div>
-          </section>
-
-          <section data-testid="borders-disclaimer">
-            <h3 className="mb-3 text-lg font-medium text-white">歴史的国境の概念的限界</h3>
+            <h3 className="mb-3 text-base font-semibold text-white">注意事項</h3>
             <p className="text-sm leading-relaxed text-gray-300">
-              現代の明確な国境線という概念は、近代国民国家の発展とともに生まれたものです。歴史上の多くの時代において、国境は流動的であり、現代のような明確な線として存在していませんでした。本アプリケーションで表示される境界線は、歴史的な支配領域を概念的に示すものであり、厳密な境界を表すものではありません。
+              本サイトの境界線・領土区分は、
+              <a
+                href="https://github.com/aourednik/historical-basemaps"
+                target="_blank"
+                rel="noopener noreferrer"
+                className={linkClass}
+              >
+                historical-basemaps
+              </a>{' '}
+              プロジェクトのデータに基づいています。これらは歴史的な支配領域を概念的に示したものであり、厳密な国境や特定の政治的立場を表すものではありません。領有や帰属の解釈は時代・資料によって異なるため、学習・調査の際は複数の信頼できる資料とあわせてご参照ください。
             </p>
           </section>
 
-          <section data-testid="disputed-disclaimer">
-            <h3 className="mb-3 text-lg font-medium text-white">係争地域について</h3>
-            <div className="rounded-lg border-l-4 border-blue-600 bg-blue-900/30 p-4">
-              <p className="text-sm text-blue-300">
-                歴史上、多くの地域は複数の勢力によって領有権が主張されており、その帰属は時代や資料によって異なる解釈が存在します。本アプリケーションで表示される領土区分は、特定の政治的立場を支持するものではなく、歴史的な参考情報として提供されています。
-              </p>
-            </div>
+          <section>
+            <h3 className="mb-3 text-base font-semibold text-white">ライセンス</h3>
+            <p className="text-sm leading-relaxed text-gray-300">
+              本サイトで使用している地図データは{' '}
+              <a
+                href="https://github.com/aourednik/historical-basemaps"
+                target="_blank"
+                rel="noopener noreferrer"
+                className={linkClass}
+              >
+                historical-basemaps
+              </a>{' '}
+              プロジェクトに基づき、
+              <strong className="font-medium text-white">
+                GNU General Public License v3.0 (GPL-3.0)
+              </strong>
+              のもとで提供されています。詳細は{' '}
+              <a
+                href="/LICENSE-data.txt"
+                target="_blank"
+                rel="noopener noreferrer"
+                className={linkClass}
+              >
+                ライセンス全文
+              </a>
+              をご覧ください。
+            </p>
           </section>
 
           <section>
-            <h3 className="mb-3 text-lg font-medium text-white">AI生成コンテンツについて</h3>
+            <h3 className="mb-3 text-base font-semibold text-white">ソースコード</h3>
             <p className="text-sm leading-relaxed text-gray-300">
-              本アプリケーションの一部のテキスト説明はAIによって生成されています。これらの説明は参考情報として提供されており、正確性や完全性は保証されません。重要な情報については、信頼できる歴史的資料をご確認ください。
+              本サイトのソースコードは{' '}
+              <a
+                href="https://github.com/akihiro-tj/world-history-map"
+                target="_blank"
+                rel="noopener noreferrer"
+                className={linkClass}
+              >
+                GitHub
+              </a>{' '}
+              で公開しています。
             </p>
           </section>
         </div>


### PR DESCRIPTION
## 概要

ライセンス・免責事項モーダルを「このサイトについて」に刷新しました。

### 背景

- 各セクションで視覚言語が混在していました（黄色警告枠・青色情報枠・グレーネスト箱・警告アイコン）。統一されたデザイン意図が感じられない状態でした
- GitHub ソースコードへのリンクが control bar のアイコンボタンとして独立していましたが、目立たせる必要がないため、モーダル内に統合することにしました

### 変更内容

**`LicenseDisclaimer` コンポーネント**
- タイトルを「ライセンス・免責事項」から「このサイトについて」に変更しました
- 5 セクションを 3 セクションに整理しました（注意事項 / ライセンス / ソースコード）
- 全セクションを同一の視覚処理（h3 + 本文テキスト）で統一し、カラーコールアウト箱と警告アイコンを削除しました
- ソースコードセクションを末尾に追加しました（GitHub リンク）

**`ControlBar` コンポーネント**
- GitHub アイコンボタンを削除しました（リンクは about modal の ソースコードセクションに移動）

## 動作確認

### 自動確認済み
- [x] `pnpm test` が全件パス（278件）
- [x] `pnpm typecheck` が通る
- [x] `pnpm verify`（typecheck + biome check）が通る

### 手動確認
- [ ] control bar に GitHub アイコンが表示されないことを確認
- [ ] about modal を開き、3 セクション（注意事項・ライセンス・ソースコード）が表示されることを確認
- [ ] 各リンク（historical-basemaps × 2、ライセンス全文、GitHub）が正しく機能することを確認

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
