### PR TITLE
style(design-tokens): switch role-loading from green to blue to match favicon

### DIFF
--- a/packages/design-tokens/src/role-colors.generated.ts
+++ b/packages/design-tokens/src/role-colors.generated.ts
@@ -2,7 +2,7 @@
 // Run `pnpm --filter @world-history-map/design-tokens run build` to regenerate.
 export const roleColors = {
   selected: '#f73d62',
-  loading: '#49d3a1',
+  loading: '#46a6ff',
   warn: '#f2a618',
   error: '#f9423d',
   focus: '#0072d5',

--- a/packages/design-tokens/src/theme.css
+++ b/packages/design-tokens/src/theme.css
@@ -12,7 +12,7 @@
   --color-primary-950: oklch(0.20 0.06 250);
 
   --color-role-selected: oklch(0.65 0.22 15);
-  --color-role-loading: oklch(0.78 0.14 165);
+  --color-role-loading: oklch(0.71 0.16 250);
   --color-role-warn: oklch(0.78 0.16 75);
   --color-role-error: oklch(0.65 0.22 27);
   --color-role-focus: oklch(0.55 0.18 250);

--- a/packages/design-tokens/tests/role-colors-builder.test.ts
+++ b/packages/design-tokens/tests/role-colors-builder.test.ts
@@ -14,7 +14,7 @@ import {
 const SAMPLE_CSS = `
 @theme {
   --color-role-selected: oklch(0.65 0.22 15);
-  --color-role-loading: oklch(0.78 0.14 165);
+  --color-role-loading: oklch(0.71 0.16 250);
   --color-role-warn: oklch(0.78 0.16 75);
   --color-role-error: oklch(0.65 0.22 27);
   --color-role-focus: oklch(0.55 0.18 250);
@@ -95,7 +95,7 @@ describe('RoleColorTokenParser', () => {
     const tokens = tokenSet.toArray();
     expect(tokens).toHaveLength(5);
     expect(tokens.find((t) => t.name === 'selected')?.value).toBe('oklch(0.65 0.22 15)');
-    expect(tokens.find((t) => t.name === 'loading')?.value).toBe('oklch(0.78 0.14 165)');
+    expect(tokens.find((t) => t.name === 'loading')?.value).toBe('oklch(0.71 0.16 250)');
   });
 
   it('ignores non-role color variables', () => {
@@ -168,7 +168,7 @@ describe('RoleColorsBuilder', () => {
     const builder = new RoleColorsBuilder({ cssSource: mockCssSource, outputPath });
     const source = await builder.generateSource();
     expect(source).toContain("selected: '#f73d62'");
-    expect(source).toContain("loading: '#49d3a1'");
+    expect(source).toContain("loading: '#46a6ff'");
     expect(source).toContain("warn: '#f2a618'");
     expect(source).toContain("error: '#f9423d'");
     expect(source).toContain("focus: '#0072d5'");


### PR DESCRIPTION
The spinner color (--color-role-loading) was unintentionally green
(oklch(0.78 0.14 165) / #49d3a1) since the role-token migration
in 7ac455c. Originally the spinner used Tailwind's blue-400, and
the refactor was meant to preserve that color via a semantic token,
but the token value was authored as green.

Restore a blue-400-equivalent (oklch(0.71 0.16 250) / #46a6ff)
aligned with the primary palette and --color-role-focus (both at
hue 250), and consistent with the blue/cyan favicon.

Regenerated role-colors.generated.ts via the design-tokens build
and updated the parser test fixture to keep it in sync with theme.css.