### PR TITLE
refactor(frontend): unify PanelState as shared RemoteData<T> type

### DIFF
--- a/apps/frontend/src/components/era-summary-panel/era-summary-panel.tsx
+++ b/apps/frontend/src/components/era-summary-panel/era-summary-panel.tsx
@@ -5,6 +5,7 @@ import { useCanScrollDown } from '@/hooks/use-can-scroll-down';
 import { useEscapeKey } from '@/hooks/use-escape-key';
 import { useIsMobile } from '@/hooks/use-is-mobile';
 import { cn } from '@/lib/utils';
+import { type RemoteData, toRemoteData } from '@/types/remote-data';
 import { useAppState } from '../../contexts/app-state-context';
 import { BottomSheet } from '../bottom-sheet/bottom-sheet';
 import { CloseButton } from '../close-button/close-button';
@@ -14,29 +15,8 @@ import { ScrollFadeOverlay } from '../scroll-fade-overlay/scroll-fade-overlay';
 import { useEraSummary } from './hooks/use-era-summary';
 import { RegionCard } from './region-card';
 
-type PanelState =
-  | { kind: 'loading' }
-  | { kind: 'error'; message: string }
-  | { kind: 'empty' }
-  | { kind: 'loaded'; summary: EraSummary };
-
-function derivePanelState({
-  summary,
-  isLoading,
-  error,
-}: {
-  summary: EraSummary | null;
-  isLoading: boolean;
-  error: string | null;
-}): PanelState {
-  if (isLoading) return { kind: 'loading' };
-  if (error) return { kind: 'error', message: error };
-  if (!summary) return { kind: 'empty' };
-  return { kind: 'loaded', summary };
-}
-
 interface ContentProps {
-  state: PanelState;
+  state: RemoteData<EraSummary>;
   yearLabel: string;
   onClose: () => void;
 }
@@ -54,7 +34,7 @@ function PanelHeader({ yearLabel, onClose }: { yearLabel: string; onClose: () =>
   );
 }
 
-function PanelBody({ state }: { state: PanelState }) {
+function PanelBody({ state }: { state: RemoteData<EraSummary> }) {
   switch (state.kind) {
     case 'loading':
       return <RoleSpinner />;
@@ -69,7 +49,7 @@ function PanelBody({ state }: { state: PanelState }) {
     case 'loaded':
       return (
         <div className="space-y-4">
-          {state.summary.regions.map((regionCard) => (
+          {state.data.regions.map((regionCard) => (
             <RegionCard key={regionCard.region} regionCard={regionCard} />
           ))}
         </div>
@@ -149,7 +129,7 @@ export function EraSummaryPanel() {
     return null;
   }
 
-  const currentState = derivePanelState({ summary, isLoading, error });
+  const currentState = toRemoteData({ data: summary, isLoading, error });
   const yearLabel = formatHistoricalYear(selectedYear);
 
   if (isMobile) {

--- a/apps/frontend/src/components/territory-info/territory-info-panel.tsx
+++ b/apps/frontend/src/components/territory-info/territory-info-panel.tsx
@@ -5,6 +5,7 @@ import { useCanScrollDown } from '@/hooks/use-can-scroll-down';
 import { useEscapeKey } from '@/hooks/use-escape-key';
 import { useIsMobile } from '@/hooks/use-is-mobile';
 import { cn } from '@/lib/utils';
+import { type RemoteData, toRemoteData } from '@/types/remote-data';
 import { useAppState } from '../../contexts/app-state-context';
 import { BottomSheet } from '../bottom-sheet/bottom-sheet';
 import { CloseButton } from '../close-button/close-button';
@@ -17,12 +18,6 @@ import { SummaryNavStrip } from './summary-nav-strip';
 import { TerritoryProfile } from './territory-profile';
 import { TerritoryTimeline } from './territory-timeline';
 
-type PanelState =
-  | { kind: 'loading'; name: string }
-  | { kind: 'error'; message: string }
-  | { kind: 'empty'; name: string }
-  | { kind: 'loaded'; description: TerritoryDescription };
-
 interface ContentProps {
   description: TerritoryDescription | null;
   isLoading: boolean;
@@ -34,14 +29,6 @@ interface ContentProps {
 
 const FALLBACK_LOADING_LABEL = '読み込み中…';
 const FALLBACK_PANEL_TITLE = '領土情報';
-
-function derivePanelState(props: ContentProps): PanelState {
-  const { description, isLoading, error, selectedTerritory } = props;
-  if (isLoading) return { kind: 'loading', name: selectedTerritory ?? FALLBACK_LOADING_LABEL };
-  if (error) return { kind: 'error', message: error };
-  if (!description) return { kind: 'empty', name: selectedTerritory ?? FALLBACK_PANEL_TITLE };
-  return { kind: 'loaded', description };
-}
 
 function PanelWrapper({
   children,
@@ -121,8 +108,12 @@ function DescriptionBody({
 }
 
 function DesktopContent(props: ContentProps) {
-  const { onClose, selectedYear } = props;
-  const state = derivePanelState(props);
+  const { onClose, selectedYear, selectedTerritory } = props;
+  const state = toRemoteData({
+    data: props.description,
+    isLoading: props.isLoading,
+    error: props.error,
+  });
   const scrollRef = useRef<HTMLDivElement>(null);
   const isLoaded = state.kind === 'loaded';
   const canScrollDown = useCanScrollDown(scrollRef, isLoaded);
@@ -132,7 +123,7 @@ function DesktopContent(props: ContentProps) {
       return (
         <PanelWrapper busy>
           <div className="shrink-0">
-            <PanelHeader name={state.name} onClose={onClose} />
+            <PanelHeader name={selectedTerritory ?? FALLBACK_LOADING_LABEL} onClose={onClose} />
           </div>
           <RoleSpinner />
         </PanelWrapper>
@@ -150,7 +141,7 @@ function DesktopContent(props: ContentProps) {
       return (
         <PanelWrapper>
           <div className="shrink-0">
-            <PanelHeader name={state.name} onClose={onClose} />
+            <PanelHeader name={selectedTerritory ?? FALLBACK_PANEL_TITLE} onClose={onClose} />
           </div>
           <NoDescriptionBody />
         </PanelWrapper>
@@ -159,14 +150,10 @@ function DesktopContent(props: ContentProps) {
       return (
         <PanelWrapper scrollable>
           <div className="shrink-0">
-            <PanelHeader
-              name={state.description.name}
-              era={state.description.era}
-              onClose={onClose}
-            />
+            <PanelHeader name={state.data.name} era={state.data.era} onClose={onClose} />
           </div>
           <div ref={scrollRef} className="overflow-y-auto">
-            <DescriptionBody description={state.description} selectedYear={selectedYear} />
+            <DescriptionBody description={state.data} selectedYear={selectedYear} />
           </div>
           <ScrollFadeOverlay show={canScrollDown} />
         </PanelWrapper>
@@ -174,14 +161,17 @@ function DesktopContent(props: ContentProps) {
   }
 }
 
-function getHeaderLabel(state: PanelState): { name: string; era: string | undefined } {
+function getHeaderLabel(
+  state: RemoteData<TerritoryDescription>,
+  selectedTerritory: string | null,
+): { name: string; era: string | undefined } {
   switch (state.kind) {
     case 'loaded':
-      return { name: state.description.name, era: state.description.era };
+      return { name: state.data.name, era: state.data.era };
     case 'error':
       return { name: 'エラー', era: undefined };
     default:
-      return { name: state.name, era: undefined };
+      return { name: selectedTerritory ?? FALLBACK_PANEL_TITLE, era: undefined };
   }
 }
 
@@ -189,7 +179,7 @@ function MobilePanelBody({
   state,
   selectedYear,
 }: {
-  state: PanelState;
+  state: RemoteData<TerritoryDescription>;
   selectedYear: HistoricalYear;
 }) {
   switch (state.kind) {
@@ -200,14 +190,18 @@ function MobilePanelBody({
     case 'empty':
       return <NoDescriptionBody />;
     case 'loaded':
-      return <DescriptionBody description={state.description} selectedYear={selectedYear} />;
+      return <DescriptionBody description={state.data} selectedYear={selectedYear} />;
   }
 }
 
 function MobileContent(props: ContentProps) {
-  const { onClose, selectedYear } = props;
-  const state = derivePanelState(props);
-  const { name: headerName, era: headerEra } = getHeaderLabel(state);
+  const { onClose, selectedYear, selectedTerritory } = props;
+  const state = toRemoteData({
+    data: props.description,
+    isLoading: props.isLoading,
+    error: props.error,
+  });
+  const { name: headerName, era: headerEra } = getHeaderLabel(state, selectedTerritory);
 
   return (
     <BottomSheet

--- a/apps/frontend/src/types/remote-data.ts
+++ b/apps/frontend/src/types/remote-data.ts
@@ -1,0 +1,20 @@
+export type RemoteData<T> =
+  | { kind: 'loading' }
+  | { kind: 'error'; message: string }
+  | { kind: 'empty' }
+  | { kind: 'loaded'; data: T };
+
+export function toRemoteData<T>({
+  data,
+  isLoading,
+  error,
+}: {
+  data: T | null;
+  isLoading: boolean;
+  error: string | null;
+}): RemoteData<T> {
+  if (isLoading) return { kind: 'loading' };
+  if (error) return { kind: 'error', message: error };
+  if (!data) return { kind: 'empty' };
+  return { kind: 'loaded', data };
+}


### PR DESCRIPTION
## 概要

close #254

`era-summary-panel` と `territory-info-panel` がそれぞれ独立して定義していた `PanelState` 型と `derivePanelState` 関数を、共通の `RemoteData<T>` ジェネリック型に統一しました。

### 背景

- 両パネルは `loading / error / empty / loaded` の 4 状態を持つ discriminated union を独立して定義していましたが、これらは「リモートデータ取得状態」という同一概念を表現しており、変換ロジックも完全に同一でした
- `TerritoryInfoPanel` の `loading` / `empty` 状態はヘッダー表示用の `name: string` を保持していましたが、これはデータ取得状態に表示メタデータを混在させる設計上の弱点でした。`selectedTerritory` は props から常に参照可能なため、レンダリング時に導出すれば state に持たせる必要がありません
- 今後パネルが追加される際も `RemoteData<T>` を再利用でき、同じパターンを繰り返し定義するコストがなくなります

### 変更内容

- `apps/frontend/src/types/remote-data.ts` を新規追加しました。`RemoteData<T>` 型と `toRemoteData<T>()` ヘルパー関数を定義しています
- `EraSummaryPanel` のローカル `PanelState` 型と `derivePanelState` 関数を `RemoteData<EraSummary>` と `toRemoteData` に置き換えました
- `TerritoryInfoPanel` のローカル `PanelState` 型と `derivePanelState` 関数を `RemoteData<TerritoryDescription>` と `toRemoteData` に置き換えました。`loading` / `empty` 状態から `name` を取り除き、ヘッダー名の導出をレンダリング時の props 参照に移行しました

## 動作確認

### 自動確認済み
- [x] `pnpm test` が全件パス
- [x] `pnpm verify`（typecheck + biome check）が通る

### 手動確認
- [x] 年代を選択して era-summary パネルを開き、loading / loaded / 空年代の表示が正常なことを確認する
- [x] 領土をクリックして territory-info パネルを開き、loading 中のヘッダー名・loaded 後の詳細・説明なし領土の empty 表示が正常なことを確認する
- [x] モバイルビュー（BottomSheet）でも同様に動作することを確認する

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
