### PR TITLE
refactor(frontend): migrate raw color primitives to semantic tokens

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -6,16 +6,22 @@ colors:
   role-warn: '#f2a618'
   role-error: '#f9423d'
   role-focus: '#0072d5'
+  role-link: '#51a2ff'
+  role-link-hover: '#8ec5ff'
   role-label-text: '#eeeeee'
   role-label-halo: '#161616'
   surface-base: '#0a0e11'
+  surface-sheet: '#1e2939'
   surface-panel: '#2a2e33f2'
   surface-raised: '#ffffff24'
+  surface-handle: '#6a7282'
   surface-border: '#44484d'
+  surface-scrim: '#00000080'
   text-primary: '#ffffff'
   text-secondary: '#d4d4d4'
   text-tertiary: '#a1a1a1'
   text-quiet: '#717171'
+  text-dimmed: '#ffffff99'
 ---
 
 # Design System: World History Map
@@ -56,14 +62,24 @@ territory* (map highlight, the panel's left accent stripe) and the *current year
 timeline (the glowing dot). Its impact depends entirely on scarcity — spend it anywhere else
 and the "you are here / now" signal dissolves.
 
+**Blue is for links only.** `role-link` (and its `role-link-hover` lift) is the lone blue in
+the UI chrome, reserved for hyperlinks — text *and* their underline decoration draw from the
+same token. Don't reuse it for emphasis or borrow `role-focus` for link text; keeping link and
+focus blues distinct preserves "named by role, not hue".
+
 **Text hierarchy is carried by lightness, not size:** `text-primary` for titles and values →
 `text-secondary` for body → `text-tertiary` for labels and metadata → `text-quiet` for
-disabled and faint elements.
+disabled and faint elements. `text-dimmed` is the separate *idle interactive* tone — a dimmed
+white for resting control-bar icons that brighten to `text-primary` on hover.
 
 **Surfaces read as a stack of slates:** the deepest base (`surface-base`) under the map void,
 with frosted panels (`surface-panel`), raised segments (`surface-raised`), and hairline
-dividers (`surface-border`). The map's own water color is a separate concern, defined in the
-map config rather than the token set.
+dividers (`surface-border`). `surface-raised` doubles as the additive white overlay that
+hover lifts a control's fill with. A darker opaque slate, `surface-sheet`, backs the
+larger-than-a-panel surfaces — the mobile bottom sheet and the map's loading/error void —
+while `surface-handle` is the bottom sheet's grab affordance and `surface-scrim` is the
+translucent black backdrop behind a modal or expanded sheet. The map's own water color is a
+separate concern, defined in the map config rather than the token set.
 
 ## Typography
 
@@ -114,8 +130,9 @@ consistency *is* the point — a surface that floats but lacks the frosted treat
 foreign element.
 
 Secondary depth cues: a **scroll-fade overlay** at a panel's bottom edge signals more content
-below; the mobile bottom sheet darkens the map behind it with a translucent scrim only when
-fully expanded.
+below — it fades from the surface it sits on (`from-surface-panel` on desktop panels,
+`from-surface-sheet` in the bottom sheet) so the gradient blends seamlessly. The mobile bottom
+sheet darkens the map behind it with a translucent `surface-scrim` only when fully expanded.
 
 ## Shapes
 
@@ -177,8 +194,9 @@ default scale (the design owns no custom radius values):
   is what makes it read as "now / here".
 - Don't mix the two color layers: territory fills (data-driven) must never leak into UI
   chrome, and chrome tokens must never paint territories.
-- Don't hardcode hex in a component when a role token exists; prefer `surface-*` tokens over
-  raw Tailwind `gray-*` (some components still ship the latter — that's drift, not the target).
+- Don't hardcode hex or reach for raw Tailwind primitives (`gray-*`, `white`, `black`,
+  `blue-*`) in chrome — every chrome color goes through a token (`surface-*`, `text-*`,
+  `role-*`). Territory fills are the only exception, and they're data, not chrome.
 - Don't add web fonts or swap the system stack casually — it breaks native Japanese rendering
   and adds load cost for no visual gain.
 - Don't size full-height surfaces to the static viewport height (`100vh`) — it causes the iOS Safari viewport jump; use `100dvh`.

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -12,7 +12,7 @@ colors:
   role-label-halo: '#161616'
   surface-base: '#0a0e11'
   surface-sheet: '#1e2939'
-  surface-panel: '#2a2e33f2'
+  surface-panel: '#364153f2'
   surface-raised: '#ffffff24'
   surface-handle: '#6a7282'
   surface-border: '#44484d'

--- a/apps/frontend/src/App.tsx
+++ b/apps/frontend/src/App.tsx
@@ -60,7 +60,7 @@ function AppContent() {
         </>
       )}
       {isMapReady && years.length > 0 && (
-        <div className="absolute inset-x-4 bottom-4 z-20 mx-auto max-w-2xl overflow-hidden rounded-lg bg-gray-700/95 shadow-lg backdrop-blur-sm">
+        <div className="absolute inset-x-4 bottom-4 z-20 mx-auto max-w-2xl overflow-hidden rounded-lg bg-surface-panel shadow-lg backdrop-blur-sm">
           <YearSelector years={years} />
         </div>
       )}

--- a/apps/frontend/src/components/bottom-sheet/bottom-sheet.stories.tsx
+++ b/apps/frontend/src/components/bottom-sheet/bottom-sheet.stories.tsx
@@ -15,14 +15,14 @@ const meta = {
     'aria-labelledby': 'sheet-title',
     header: (
       <div className="px-4 pb-3">
-        <h2 id="sheet-title" className="text-lg font-semibold text-white">
+        <h2 id="sheet-title" className="text-lg font-semibold text-text-primary">
           フランス王国
         </h2>
-        <p className="text-sm text-gray-300">絶対王政期</p>
+        <p className="text-sm text-text-secondary">絶対王政期</p>
       </div>
     ),
     children: (
-      <div className="space-y-3 px-4 pb-4 text-sm text-gray-300">
+      <div className="space-y-3 px-4 pb-4 text-sm text-text-secondary">
         <p>
           1700年のフランスはルイ14世の親政期にあり、ヨーロッパ最大の人口約2000万人を擁した。翌1701年にはスペイン継承戦争が勃発する。
         </p>

--- a/apps/frontend/src/components/bottom-sheet/bottom-sheet.tsx
+++ b/apps/frontend/src/components/bottom-sheet/bottom-sheet.tsx
@@ -41,7 +41,7 @@ export function BottomSheet({ isOpen, onClose, header, children, ...props }: Bot
       {snap === 'expanded' && (
         <button
           type="button"
-          className="fixed inset-0 z-30 cursor-default border-none bg-black/50"
+          className="fixed inset-0 z-30 cursor-default border-none bg-surface-scrim"
           data-testid="bottom-sheet-backdrop"
           onClick={onClose}
           aria-label="Close"
@@ -52,14 +52,17 @@ export function BottomSheet({ isOpen, onClose, header, children, ...props }: Bot
         role="dialog"
         aria-labelledby={props['aria-labelledby']}
         style={sheetStyle}
-        className="fixed inset-x-0 bottom-0 z-40 flex flex-col rounded-t-2xl bg-gray-800 shadow-xl"
+        className="fixed inset-x-0 bottom-0 z-40 flex flex-col rounded-t-2xl bg-surface-sheet shadow-xl"
       >
         <div
           ref={headerRef}
           className={cn('shrink-0 touch-none', isDragging ? 'cursor-grabbing' : 'cursor-grab')}
         >
           <div className="flex justify-center pt-2 pb-1">
-            <div className="h-1 w-10 rounded-full bg-gray-500" data-testid="bottom-sheet-handle" />
+            <div
+              className="h-1 w-10 rounded-full bg-surface-handle"
+              data-testid="bottom-sheet-handle"
+            />
           </div>
           {header}
         </div>
@@ -70,7 +73,7 @@ export function BottomSheet({ isOpen, onClose, header, children, ...props }: Bot
           >
             {children}
           </div>
-          <ScrollFadeOverlay show={showFade} fromColor="from-gray-800" />
+          <ScrollFadeOverlay show={showFade} fromColor="from-surface-sheet" />
         </div>
       </div>
     </>,

--- a/apps/frontend/src/components/close-button/close-button.tsx
+++ b/apps/frontend/src/components/close-button/close-button.tsx
@@ -14,7 +14,7 @@ export const CloseButton = forwardRef<HTMLButtonElement, CloseButtonProps>(
         ref={ref}
         type="button"
         className={cn(
-          'rounded-lg text-gray-300 transition-colors hover:bg-gray-600 hover:text-white',
+          'rounded-lg text-text-secondary transition-colors hover:bg-surface-raised hover:text-text-primary',
           size === 'sm' ? 'p-1' : 'p-1.5',
           className,
         )}

--- a/apps/frontend/src/components/control-bar/control-bar.tsx
+++ b/apps/frontend/src/components/control-bar/control-bar.tsx
@@ -13,14 +13,14 @@ export function ControlBar({ onOpenLicense }: ControlBarProps) {
       <ProjectionToggle
         projection={projection}
         onToggle={setProjection}
-        className="bg-gray-700/95 p-3 text-white/60 shadow-lg backdrop-blur-sm transition-colors hover:text-white"
+        className="bg-surface-panel p-3 text-text-dimmed shadow-lg backdrop-blur-sm transition-colors hover:text-text-primary"
         data-testid="projection-toggle"
       />
       <button
         type="button"
         data-testid="license-link"
         onClick={onOpenLicense}
-        className="rounded-lg bg-gray-700/95 p-3 text-white/60 shadow-lg backdrop-blur-sm transition-colors hover:text-white"
+        className="rounded-lg bg-surface-panel p-3 text-text-dimmed shadow-lg backdrop-blur-sm transition-colors hover:text-text-primary"
       >
         <svg
           className="h-6 w-6"

--- a/apps/frontend/src/components/era-summary-panel/era-summary-panel.stories.tsx
+++ b/apps/frontend/src/components/era-summary-panel/era-summary-panel.stories.tsx
@@ -67,7 +67,7 @@ const meta = {
   tags: ['autodocs'],
   decorators: [
     (Story) => (
-      <div className="relative h-dvh w-screen overflow-hidden bg-gray-900">
+      <div className="relative h-dvh w-screen overflow-hidden bg-surface-sheet">
         <AppStateProvider initialState={openSummaryState}>
           <Story />
         </AppStateProvider>

--- a/apps/frontend/src/components/era-summary-panel/era-summary-panel.tsx
+++ b/apps/frontend/src/components/era-summary-panel/era-summary-panel.tsx
@@ -23,9 +23,9 @@ interface ContentProps {
 
 function PanelHeader({ yearLabel, onClose }: { yearLabel: string; onClose: () => void }) {
   return (
-    <div className="border-b border-gray-600">
+    <div className="border-b border-surface-border">
       <div className="flex items-center justify-between px-4 py-3">
-        <h2 id="era-summary-title" className="text-lg font-semibold text-white">
+        <h2 id="era-summary-title" className="text-lg font-semibold text-text-primary">
           {yearLabel}年の世界
         </h2>
         <CloseButton onClick={onClose} aria-label="閉じる" />
@@ -42,7 +42,7 @@ function PanelBody({ state }: { state: RemoteData<EraSummary> }) {
       return <RoleErrorMessage>{state.message}</RoleErrorMessage>;
     case 'empty':
       return (
-        <div role="status" className="py-6 text-center text-sm text-gray-300">
+        <div role="status" className="py-6 text-center text-sm text-text-secondary">
           この年代の概要は準備中です。
         </div>
       );
@@ -70,7 +70,7 @@ function DesktopContent({ state, yearLabel, onClose }: ContentProps) {
       aria-labelledby="era-summary-title"
       aria-busy={isLoading || undefined}
       className={cn(
-        'absolute left-4 top-4 z-30 w-96 max-w-[calc(100vw-2rem)] flex flex-col overflow-hidden rounded-lg bg-gray-700/95 shadow-xl backdrop-blur-sm',
+        'absolute left-4 top-4 z-30 w-96 max-w-[calc(100vw-2rem)] flex flex-col overflow-hidden rounded-lg bg-surface-panel shadow-xl backdrop-blur-sm',
         isLoaded && 'max-h-[calc(100vh-2rem)]',
       )}
     >
@@ -95,8 +95,8 @@ function MobileContent({ state, yearLabel, onClose }: ContentProps) {
       isOpen
       onClose={onClose}
       header={
-        <div className="flex items-center justify-between border-b border-gray-600 px-4 pb-2">
-          <h2 id="era-summary-title" className="text-lg font-semibold text-white">
+        <div className="flex items-center justify-between border-b border-surface-border px-4 pb-2">
+          <h2 id="era-summary-title" className="text-lg font-semibold text-text-primary">
             {yearLabel}年の世界
           </h2>
           <CloseButton aria-label="閉じる" onClick={onClose} />

--- a/apps/frontend/src/components/era-summary-panel/region-card.tsx
+++ b/apps/frontend/src/components/era-summary-panel/region-card.tsx
@@ -9,11 +9,11 @@ interface RegionCardProps {
 export function RegionCard({ regionCard, className }: RegionCardProps) {
   return (
     <article className={className}>
-      <h3 className="text-sm font-semibold text-white">{regionCard.title}</h3>
+      <h3 className="text-sm font-semibold text-text-primary">{regionCard.title}</h3>
       {regionCard.references.length > 0 ? (
         <SummaryReferences context={regionCard.context} references={regionCard.references} />
       ) : (
-        <p className="mt-1 text-sm leading-relaxed text-gray-300">{regionCard.context}</p>
+        <p className="mt-1 text-sm leading-relaxed text-text-secondary">{regionCard.context}</p>
       )}
     </article>
   );

--- a/apps/frontend/src/components/era-summary-panel/summary-references.tsx
+++ b/apps/frontend/src/components/era-summary-panel/summary-references.tsx
@@ -51,7 +51,7 @@ export function SummaryReferences({ context, references }: SummaryReferencesProp
   const segments = annotated.segments(availableYears);
 
   return (
-    <p className="mt-1 text-sm leading-relaxed text-gray-300">
+    <p className="mt-1 text-sm leading-relaxed text-text-secondary">
       {segments.map((segment, index) =>
         renderSegment(segment, `${segment.kind}-${index}`, actions),
       )}

--- a/apps/frontend/src/components/era-summary-panel/summary-trigger.tsx
+++ b/apps/frontend/src/components/era-summary-panel/summary-trigger.tsx
@@ -31,7 +31,7 @@ export function SummaryTrigger() {
       type="button"
       aria-label="概要を開く"
       onClick={() => actions.openSummary()}
-      className="flex items-center gap-1.5 rounded-full bg-gray-700/95 px-4 py-2.5 text-sm text-white shadow-lg backdrop-blur-sm transition-colors hover:bg-gray-600/95"
+      className="flex items-center gap-1.5 rounded-full bg-surface-panel px-4 py-2.5 text-sm text-text-primary shadow-lg backdrop-blur-sm transition-colors hover:bg-surface-raised"
     >
       <ListBulletIcon />
       <span>概要</span>

--- a/apps/frontend/src/components/legal/license-disclaimer.tsx
+++ b/apps/frontend/src/components/legal/license-disclaimer.tsx
@@ -9,7 +9,7 @@ export interface LicenseDisclaimerProps {
 }
 
 const linkClass =
-  'text-blue-400 hover:text-blue-300 underline decoration-blue-400/40 hover:decoration-blue-300 underline-offset-2 transition-colors';
+  'text-role-link hover:text-role-link-hover underline decoration-role-link/40 hover:decoration-role-link-hover underline-offset-2 transition-colors';
 
 export function LicenseDisclaimer({ isOpen, onClose }: LicenseDisclaimerProps) {
   const modalRef = useRef<HTMLDivElement>(null);
@@ -51,17 +51,17 @@ export function LicenseDisclaimer({ isOpen, onClose }: LicenseDisclaimerProps) {
     >
       <div
         data-testid="license-modal-backdrop"
-        className="absolute inset-0 bg-black/50 backdrop-blur-sm"
+        className="absolute inset-0 bg-surface-scrim backdrop-blur-sm"
         onClick={onClose}
         aria-hidden="true"
       />
 
       <div
         data-testid="license-modal-content"
-        className="relative z-10 mx-4 max-h-[90vh] w-full max-w-2xl overflow-y-auto rounded-lg bg-gray-700 p-6 shadow-2xl sm:p-8"
+        className="relative z-10 mx-4 max-h-[90vh] w-full max-w-2xl overflow-y-auto rounded-lg bg-surface-panel p-6 shadow-2xl sm:p-8"
       >
-        <div className="mb-7 flex items-start justify-between border-b border-gray-600 pb-4">
-          <h2 id="license-disclaimer-title" className="text-xl font-semibold text-white">
+        <div className="mb-7 flex items-start justify-between border-b border-surface-border pb-4">
+          <h2 id="license-disclaimer-title" className="text-xl font-semibold text-text-primary">
             このサイトについて
           </h2>
           <CloseButton ref={closeButtonRef} onClick={onClose} aria-label="閉じる" />
@@ -69,8 +69,8 @@ export function LicenseDisclaimer({ isOpen, onClose }: LicenseDisclaimerProps) {
 
         <div className="space-y-8">
           <section>
-            <h3 className="mb-3 text-base font-semibold text-white">注意事項</h3>
-            <p className="text-sm leading-relaxed text-gray-300">
+            <h3 className="mb-3 text-base font-semibold text-text-primary">注意事項</h3>
+            <p className="text-sm leading-relaxed text-text-secondary">
               本サイトの境界線・領土区分は、
               <a
                 href="https://github.com/aourednik/historical-basemaps"
@@ -85,8 +85,8 @@ export function LicenseDisclaimer({ isOpen, onClose }: LicenseDisclaimerProps) {
           </section>
 
           <section>
-            <h3 className="mb-3 text-base font-semibold text-white">ライセンス</h3>
-            <p className="text-sm leading-relaxed text-gray-300">
+            <h3 className="mb-3 text-base font-semibold text-text-primary">ライセンス</h3>
+            <p className="text-sm leading-relaxed text-text-secondary">
               本サイトで使用している地図データは André Ourednik 氏による{' '}
               <a
                 href="https://github.com/aourednik/historical-basemaps"
@@ -97,7 +97,7 @@ export function LicenseDisclaimer({ isOpen, onClose }: LicenseDisclaimerProps) {
                 historical-basemaps
               </a>{' '}
               プロジェクトに基づき、
-              <strong className="font-medium text-white">
+              <strong className="font-medium text-text-primary">
                 GNU General Public License v3.0 (GPL-3.0)
               </strong>
               のもとで提供されています。詳細は{' '}
@@ -114,8 +114,8 @@ export function LicenseDisclaimer({ isOpen, onClose }: LicenseDisclaimerProps) {
           </section>
 
           <section>
-            <h3 className="mb-3 text-base font-semibold text-white">ソースコード</h3>
-            <p className="text-sm leading-relaxed text-gray-300">
+            <h3 className="mb-3 text-base font-semibold text-text-primary">ソースコード</h3>
+            <p className="text-sm leading-relaxed text-text-secondary">
               本サイトのソースコードは{' '}
               <a
                 href="https://github.com/akihiro-tj/world-history-map"

--- a/apps/frontend/src/components/map/map-view.tsx
+++ b/apps/frontend/src/components/map/map-view.tsx
@@ -89,7 +89,7 @@ export function MapView({ onReady }: MapViewProps) {
   if (error) {
     return (
       <div
-        className="flex h-screen w-full items-center justify-center bg-gray-900"
+        className="flex h-screen w-full items-center justify-center bg-surface-sheet"
         data-testid="map-error"
       >
         <div className="text-center">
@@ -133,7 +133,7 @@ export function MapView({ onReady }: MapViewProps) {
                 <ellipse cx="12" cy="12" rx="10" ry="4" opacity="0.5" />
               </svg>
             </div>
-            <span className="mt-5 text-sm tracking-wider text-gray-400">Loading...</span>
+            <span className="mt-5 text-sm tracking-wider text-text-tertiary">Loading...</span>
           </div>
         </output>
       )}

--- a/apps/frontend/src/components/map/projection-toggle.tsx
+++ b/apps/frontend/src/components/map/projection-toggle.tsx
@@ -22,7 +22,7 @@ export const ProjectionToggle = forwardRef<HTMLButtonElement, ProjectionTogglePr
         type="button"
         onClick={handleClick}
         className={cn(
-          'rounded-lg bg-gray-700/95 p-3 text-gray-300 shadow-lg backdrop-blur-sm transition-colors hover:bg-gray-600 hover:text-white',
+          'rounded-lg bg-surface-panel p-3 text-text-secondary shadow-lg backdrop-blur-sm transition-colors hover:bg-surface-raised hover:text-text-primary',
           className,
         )}
         aria-label={isGlobe ? '平面地図に切り替え' : '地球儀表示に切り替え'}

--- a/apps/frontend/src/components/scroll-fade-overlay/scroll-fade-overlay.tsx
+++ b/apps/frontend/src/components/scroll-fade-overlay/scroll-fade-overlay.tsx
@@ -5,7 +5,10 @@ interface ScrollFadeOverlayProps {
   fromColor?: string;
 }
 
-export function ScrollFadeOverlay({ show, fromColor = 'from-gray-700' }: ScrollFadeOverlayProps) {
+export function ScrollFadeOverlay({
+  show,
+  fromColor = 'from-surface-panel',
+}: ScrollFadeOverlayProps) {
   return (
     <div
       aria-hidden="true"

--- a/apps/frontend/src/components/territory-info/summary-nav-strip.tsx
+++ b/apps/frontend/src/components/territory-info/summary-nav-strip.tsx
@@ -11,7 +11,7 @@ export function SummaryNavStrip() {
       type="button"
       aria-label={`${yearLabel}年の世界の概要を開く`}
       onClick={() => actions.openSummary()}
-      className="flex w-max items-center gap-1 rounded-sm text-xs text-gray-300 underline hover:no-underline focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-gray-400"
+      className="flex w-max items-center gap-1 rounded-sm text-xs text-text-secondary underline hover:no-underline focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-role-focus"
     >
       <svg
         className="h-3 w-3 shrink-0"

--- a/apps/frontend/src/components/territory-info/territory-info-panel.tsx
+++ b/apps/frontend/src/components/territory-info/territory-info-panel.tsx
@@ -46,7 +46,7 @@ function PanelWrapper({
       aria-labelledby="territory-info-title"
       aria-busy={busy || undefined}
       className={cn(
-        'absolute left-4 top-4 z-30 w-96 max-w-[calc(100vw-2rem)] flex flex-col overflow-hidden rounded-lg bg-gray-700/95 shadow-xl backdrop-blur-sm',
+        'absolute left-4 top-4 z-30 w-96 max-w-[calc(100vw-2rem)] flex flex-col overflow-hidden rounded-lg bg-surface-panel shadow-xl backdrop-blur-sm',
         SELECTED_ACCENT_CLASS,
         scrollable && 'max-h-[calc(100vh-2rem)]',
       )}
@@ -66,14 +66,14 @@ function PanelHeader({
   onClose: () => void;
 }) {
   return (
-    <div className="border-b border-gray-600">
+    <div className="border-b border-surface-border">
       <div className="flex items-start justify-between px-4 py-3">
         <div className="min-w-0 flex-1">
           <SummaryNavStrip />
-          <h2 id="territory-info-title" className="mt-2.5 text-lg font-semibold text-white">
+          <h2 id="territory-info-title" className="mt-2.5 text-lg font-semibold text-text-primary">
             {name}
           </h2>
-          {era && <p className="mt-0.5 text-sm text-gray-300">{era}</p>}
+          {era && <p className="mt-0.5 text-sm text-text-secondary">{era}</p>}
         </div>
         <CloseButton aria-label="閉じる" onClick={onClose} />
       </div>
@@ -83,7 +83,7 @@ function PanelHeader({
 
 function NoDescriptionBody() {
   return (
-    <div data-testid="no-description-message" className="p-4 text-center text-gray-300">
+    <div data-testid="no-description-message" className="p-4 text-center text-text-secondary">
       <p>この領土の詳細情報は準備中です。</p>
     </div>
   );
@@ -100,7 +100,7 @@ function DescriptionBody({
     <div data-testid="territory-description" className="space-y-3 px-4 py-4">
       <TerritoryProfile profile={description.profile} />
       {description.context && (
-        <p className="text-sm leading-relaxed text-gray-300">{description.context}</p>
+        <p className="text-sm leading-relaxed text-text-secondary">{description.context}</p>
       )}
       <TerritoryTimeline keyEvents={description.keyEvents} selectedYear={selectedYear} />
     </div>
@@ -208,7 +208,7 @@ function MobileContent(props: ContentProps) {
       isOpen
       onClose={onClose}
       header={
-        <div className="flex items-start border-b border-gray-600 pr-4">
+        <div className="flex items-start border-b border-surface-border pr-4">
           <div className="min-w-0 flex-1">
             <div className="pl-4 pr-2">
               <SummaryNavStrip />
@@ -216,11 +216,13 @@ function MobileContent(props: ContentProps) {
             <SelectedAccent className="mt-2 pl-3 pr-2 pb-1.5">
               <h2
                 id="territory-info-title"
-                className="leading-tight text-lg font-semibold text-white"
+                className="leading-tight text-lg font-semibold text-text-primary"
               >
                 {headerName}
               </h2>
-              {headerEra && <p className="leading-tight text-sm text-gray-300">{headerEra}</p>}
+              {headerEra && (
+                <p className="leading-tight text-sm text-text-secondary">{headerEra}</p>
+              )}
             </SelectedAccent>
           </div>
           <CloseButton aria-label="閉じる" onClick={onClose} className="shrink-0" />

--- a/apps/frontend/src/components/territory-info/territory-profile.tsx
+++ b/apps/frontend/src/components/territory-info/territory-profile.tsx
@@ -12,8 +12,8 @@ export function TerritoryProfile({ profile }: { profile: TerritoryProfileType | 
     <dl className="grid grid-cols-[auto_1fr] gap-x-4 gap-y-1.5 text-sm">
       {entries.map((field) => (
         <div key={field} className="contents">
-          <dt className="text-gray-400">{PROFILE_FIELD_LABELS[field]}</dt>
-          <dd className="text-white">{profile[field]}</dd>
+          <dt className="text-text-tertiary">{PROFILE_FIELD_LABELS[field]}</dt>
+          <dd className="text-text-primary">{profile[field]}</dd>
         </div>
       ))}
     </dl>

--- a/apps/frontend/src/components/territory-info/timeline-row-style.ts
+++ b/apps/frontend/src/components/territory-info/timeline-row-style.ts
@@ -34,7 +34,7 @@ const CURRENT_ROW_STYLE: TimelineRowStyle = {
     boxShadow: `0 0 ${TIMELINE_CURRENT_DOT_GLOW_PX}px var(--color-role-selected)`,
   },
   yearClassName: 'shrink-0 text-xs tabular-nums text-role-selected',
-  eventClassName: 'text-sm text-white',
+  eventClassName: 'text-sm text-text-primary',
 };
 
 const FUTURE_ROW_STYLE: TimelineRowStyle = {

--- a/apps/frontend/src/components/year-display/year-display.tsx
+++ b/apps/frontend/src/components/year-display/year-display.tsx
@@ -26,7 +26,7 @@ export function YearDisplay({ year }: YearDisplayProps) {
     <div
       aria-live="polite"
       className={cn(
-        'rounded-lg bg-gray-800/80 px-4 py-2 text-3xl font-bold text-white shadow-lg backdrop-blur-sm transition-opacity duration-150',
+        'rounded-lg bg-surface-panel px-4 py-2 text-3xl font-bold text-text-primary shadow-lg backdrop-blur-sm transition-opacity duration-150',
         visible ? 'opacity-100' : 'opacity-0',
       )}
     >

--- a/apps/frontend/src/components/year-selector/year-selector.stories.tsx
+++ b/apps/frontend/src/components/year-selector/year-selector.stories.tsx
@@ -36,7 +36,7 @@ const meta = {
           mapView: { longitude: 0, latitude: 30, zoom: 2 },
         }}
       >
-        <div className="bg-gray-700 p-4">
+        <div className="bg-surface-panel p-4">
           <Story />
         </div>
       </AppStateProvider>
@@ -75,7 +75,7 @@ export const ManyYears: Story = {
           mapView: { longitude: 0, latitude: 30, zoom: 2 },
         }}
       >
-        <div className="bg-gray-700 p-4">
+        <div className="bg-surface-panel p-4">
           <Story />
         </div>
       </AppStateProvider>

--- a/apps/frontend/src/components/year-selector/year-selector.tsx
+++ b/apps/frontend/src/components/year-selector/year-selector.tsx
@@ -119,10 +119,10 @@ export function YearSelector({ years, onYearSelect }: YearSelectorProps) {
         disabled={!canGoPrev}
         aria-label="前の年代を選択"
         className={cn(
-          'flex shrink-0 items-center border-r border-gray-600 px-3 py-2 transition-colors',
+          'flex shrink-0 items-center border-r border-surface-border px-3 py-2 transition-colors',
           canGoPrev
-            ? 'text-gray-300 hover:bg-gray-600 hover:text-white'
-            : 'cursor-not-allowed text-gray-500',
+            ? 'text-text-secondary hover:bg-surface-raised hover:text-text-primary'
+            : 'cursor-not-allowed text-text-quiet',
         )}
       >
         <svg
@@ -152,10 +152,10 @@ export function YearSelector({ years, onYearSelect }: YearSelectorProps) {
               onClick={() => handleYearClick(yearEntry.year)}
               onKeyDown={(e) => handleKeyDown(e, index)}
               className={cn(
-                'flex shrink-0 items-center justify-center border-r border-gray-600 py-3 font-medium transition-colors last:border-r-0',
+                'flex shrink-0 items-center justify-center border-r border-surface-border py-3 font-medium transition-colors last:border-r-0',
                 isSelected
-                  ? 'min-w-[5rem] bg-surface-raised px-5 text-xl font-bold text-white'
-                  : 'min-w-[4rem] px-3 text-base text-gray-300 hover:bg-gray-600 hover:text-white',
+                  ? 'min-w-[5rem] bg-surface-raised px-5 text-xl font-bold text-text-primary'
+                  : 'min-w-[4rem] px-3 text-base text-text-secondary hover:bg-surface-raised hover:text-text-primary',
               )}
             >
               {formatHistoricalYear(yearEntry.year)}
@@ -170,10 +170,10 @@ export function YearSelector({ years, onYearSelect }: YearSelectorProps) {
         disabled={!canGoNext}
         aria-label="次の年代を選択"
         className={cn(
-          'flex shrink-0 items-center border-l border-gray-600 px-3 py-2 transition-colors',
+          'flex shrink-0 items-center border-l border-surface-border px-3 py-2 transition-colors',
           canGoNext
-            ? 'text-gray-300 hover:bg-gray-600 hover:text-white'
-            : 'cursor-not-allowed text-gray-500',
+            ? 'text-text-secondary hover:bg-surface-raised hover:text-text-primary'
+            : 'cursor-not-allowed text-text-quiet',
         )}
       >
         <svg

--- a/packages/design-tokens/src/role-colors.generated.ts
+++ b/packages/design-tokens/src/role-colors.generated.ts
@@ -6,6 +6,8 @@ export const roleColors = {
   warn: '#f2a618',
   error: '#f9423d',
   focus: '#0072d5',
+  link: '#51a2ff',
+  linkHover: '#8ec5ff',
   labelText: '#eeeeee',
   labelHalo: '#161616',
 } as const;

--- a/packages/design-tokens/src/theme.css
+++ b/packages/design-tokens/src/theme.css
@@ -12,7 +12,7 @@
   --color-role-label-halo: #161616;
   --color-surface-base: #0a0e11;
   --color-surface-sheet: #1e2939;
-  --color-surface-panel: #2a2e33f2;
+  --color-surface-panel: #364153f2;
   --color-surface-raised: #ffffff24;
   --color-surface-handle: #6a7282;
   --color-surface-border: #44484d;

--- a/packages/design-tokens/src/theme.css
+++ b/packages/design-tokens/src/theme.css
@@ -6,14 +6,20 @@
   --color-role-warn: #f2a618;
   --color-role-error: #f9423d;
   --color-role-focus: #0072d5;
+  --color-role-link: #51a2ff;
+  --color-role-link-hover: #8ec5ff;
   --color-role-label-text: #eeeeee;
   --color-role-label-halo: #161616;
   --color-surface-base: #0a0e11;
+  --color-surface-sheet: #1e2939;
   --color-surface-panel: #2a2e33f2;
   --color-surface-raised: #ffffff24;
+  --color-surface-handle: #6a7282;
   --color-surface-border: #44484d;
+  --color-surface-scrim: #00000080;
   --color-text-primary: #ffffff;
   --color-text-secondary: #d4d4d4;
   --color-text-tertiary: #a1a1a1;
   --color-text-quiet: #717171;
+  --color-text-dimmed: #ffffff99;
 }


### PR DESCRIPTION
close #280

Replace raw Tailwind primitives (gray-*, white, black/50, blue-*) in
the frontend chrome with the semantic color tokens defined in DESIGN.md,
resolving the mixed/drifted state left after #278.

- Add tokens to DESIGN.md frontmatter (regenerate theme.css +
  role-colors.generated.ts): role-link / role-link-hover (links),
  surface-sheet (bottom sheet / map void), surface-handle (drag handle),
  surface-scrim (backdrops), text-dimmed (idle control icons).
- Map panel backgrounds to bg-surface-panel, dividers to
  border-surface-border, hover/raised fills to bg-surface-raised, text to
  the text-* hierarchy, focus ring to ring-role-focus.
- Update DESIGN.md prose (Colors, Surfaces, Elevation, Do/Don't) to
  document the new token families.

No raw gray-*/white/black/blue-* primitives remain in apps/frontend/src.