### PR TITLE
chore(skills): add project-scoped design-mock skill

### DIFF
--- a/.claude/skills/design-mock/SKILL.md
+++ b/.claude/skills/design-mock/SKILL.md
@@ -1,0 +1,120 @@
+---
+name: design-mock
+description: >-
+  design-mocks/ 配下に、DESIGN.md と生成済みデザイントークンに則った単一 HTML モックを生成するスキル。
+  新機能をいきなり実装に入らず、まずモックで確認・比較検討したいときに使う。
+  DESIGN.md（ルール・意図）・theme.css（トークン）・実コンポーネント（具体レシピ）を実行時に参照し、
+  トークン utility でモックを組む。design-mocks/<feature>/v<n>/ にバージョン並列で保存しブラウザで開く。
+argument-hint: "<モックしたい画面・機能の説明>"
+disable-model-invocation: true
+allowed-tools: ["Bash", "Glob", "Read", "Write", "Edit", "AskUserQuestion"]
+---
+
+# design-mock
+
+実装前のデザイン確認・構造比較検討のために、単一 HTML のモックを生成して即ブラウザで開くスキル。
+
+**引数**: "$ARGUMENTS"
+
+## デザインの拠り所
+
+モックは次を生成時に参照して組む:
+
+- **色 / タイポ / spacing** — `packages/design-tokens/src/theme.css` の `@theme` をモックに注入し、
+  `bg-surface-panel` `text-panel-title` `border-surface-border` 等のトークン utility で書く。
+- **ルール・意図** — `DESIGN.md`（Overview / Colors / Typography / Layout / Elevation / Shapes /
+  Components / Do's and Don'ts）に従う。
+- **具体レシピ**（frosted panel の class 構成・状態表現・rose ストライプ等）— 該当する実コンポーネントに合わせる。
+
+## 出力構造
+
+```text
+<リポジトリルート>/design-mocks/
+├── index.html                  # 全モックのナビゲーション（毎回再生成）
+└── <feature-name>/             # kebab-case
+    ├── v1/index.html
+    ├── v2/index.html
+    └── ...
+```
+
+- `feature-name` は kebab-case。同一 feature への新規モックは v2, v3… と並列保持し既存版は上書きしない。
+- 比較検討は構造の差（例: モーダル vs ボトムシート、表 vs カード）で行い、どの案も DESIGN.md に準拠させる。
+
+## ワークフロー
+
+### Step 1: 要件確認
+
+1. `$ARGUMENTS` からモック対象を抽出する。
+2. `Glob design-mocks/*/` で既存 feature / version を把握する。
+3. 次を「確定済み / 不足」に分類する: feature 名（kebab-case） / 対象 UI の種別（floating panel・FAB・
+   bottom sheet・year selector 等） / async か（→ 表示する状態） / desktop と mobile の両方を出すか /
+   今回複数の構造案を並べて比較するか（する場合はどの軸で） / 新規 feature か既存 version の反復か。
+4. **不足が 1 つでもあれば** `AskUserQuestion` で確認する。判定経緯は最終報告に残す。
+
+### Step 2: デザイン源を読む
+
+生成の直前にその時点の最新を読み、Step 4 で使う:
+
+1. `DESIGN.md` 全文 — Overview / Colors / Typography / Layout / Elevation / Shapes / Components /
+   **Do's and Don'ts**。
+2. `packages/design-tokens/src/theme.css` — 注入する `@theme{...}`。利用可能なトークン utility 名の一覧でもある。
+3. `apps/frontend/src/index.css` — base 設定（system font stack / `prefers-reduced-motion` / `:focus-visible` 等）。
+4. 対象に近い**実コンポーネント** 1〜2 個を `Glob`/`Read` で特定して読む。例:
+   `apps/frontend/src/components/territory-info/territory-info-panel.tsx`（frosted panel・RemoteData の状態）、
+   `year-display/`、`year-selector/`、`era-summary-panel/`、`bottom-sheet/`、`feedback/`。
+
+### Step 3: ディレクトリ / バージョン決定
+
+1. `Glob design-mocks/<feature-name>/v*/` で既存 version を取得し、次番号を決める（最大値 +1、なければ v1）。
+2. `mkdir -p design-mocks/<feature-name>/v<n>/`。
+
+### Step 4: モック生成
+
+`references/mock-shell.html` を雛形として複製し、マーカーを埋める:
+
+1. **theme.css 注入**: `<style type="text/tailwindcss">` 内の `INJECT:` マーカーを、`theme.css` の `@theme{...}`
+   の中身でそのまま置換する。
+2. **base CSS 注入**: 2 つ目の `<style>` 内の `INJECT:` マーカーを、`index.css` の base 設定で置換する。
+   `@import` 行は除き、`:root` のフォント設定・`@media (prefers-reduced-motion)`・`:focus-visible`・`.sr-only`
+   など CDN で動く CSS だけを残す。`var(--color-*)` は `@theme` 由来でそのまま使える。
+3. **メタ帯 / コンテンツスロット**: feature 名・version・関連リンクを埋め、`{{DESKTOP_MOCK}}` /
+   `{{MOBILE_MOCK}}` に実 UI を組む。
+   - chrome は全てトークン utility で書く。
+   - 具体構成は Step 2 で読んだ実コンポーネントに合わせる（frosted treatment・header の hairline・状態表現など）。
+   - DESIGN.md の Layout / Elevation / Shapes / Components の原則に従う。
+   - async なら各状態を `[data-state="..."]` で用意する。async でなければ状態スイッチャ（`[data-state-switcher]`）を削除する。
+   - mobile は re-home（FAB + bottom sheet）として組む。
+   - 複数構造案の比較時は version を分ける（v1, v2…）か、同一 desktop 枠内に並置する。いずれも DESIGN.md 準拠。
+
+### Step 5: ルート index.html を再生成
+
+1. `Glob design-mocks/*/v*/index.html` を全列挙する。
+2. `design-mocks/index.html` を再生成する。`mock-shell.html` と同じ要領で theme.css / base CSS を注入し、
+   トークン utility で組んだ feature × version の一覧（各モックへの相対リンク）にする。ナビ目的なので簡素でよい。
+
+### Step 6: セルフレビュー
+
+`DESIGN.md` の `## Do's and Don'ts` を読み直し、生成した HTML を各項目に照合する。違反があれば修正する。
+**再生成は最大 1 回**まで。
+
+### Step 7: open + 報告
+
+```bash
+open design-mocks/<feature-name>/v<n>/index.html
+```
+
+ユーザーに報告する:
+- 生成パス / 表示した状態 / 構造案 / 前 version からの差分（あれば）
+- Step 6 のセルフレビュー結果（DESIGN.md の Do/Don't と照合した結果、修正の有無）
+- ルート index.html のパス（`open design-mocks/index.html`）
+
+### Step 8: 反復（必要時）
+
+修正指示があれば `AskUserQuestion` で扱いを確認する:
+- **大幅変更** → v(n+1) として新規作成（Step 2 から再実行）
+- **軽微な調整** → 現 version を直接編集（編集後も Step 6 を再実行）
+
+## 注意事項
+
+- 触ってよいのは `design-mocks/` 配下のみ。プロダクションコードや DESIGN.md / theme.css は変更しない。
+- `.gitignore` への追加可否はユーザー判断に委ねる（自動追加しない）。

--- a/.claude/skills/design-mock/references/mock-shell.html
+++ b/.claude/skills/design-mock/references/mock-shell.html
@@ -1,0 +1,105 @@
+<!doctype html>
+<!--
+  design-mock のモック雛形。design-mock スキルが複製して使う。
+
+  `INJECT:` マーカーは生成時にライブのソースから埋める:
+
+    1. theme.css 注入  … packages/design-tokens/src/theme.css の @theme{...}
+    2. base CSS 注入   … apps/frontend/src/index.css の base 設定（CDN で動く形に整える）
+
+  chrome（フレーム枠・ラベル・背景）は `bg-surface-base` 等のトークン utility で書く。
+-->
+<html lang="ja">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>{{TITLE}}</title>
+    <script src="https://cdn.jsdelivr.net/npm/@tailwindcss/browser@4"></script>
+
+    <style type="text/tailwindcss">
+      /* INJECT: packages/design-tokens/src/theme.css の @theme{...} をそのまま貼る */
+    </style>
+
+    <style>
+      /* INJECT: apps/frontend/src/index.css の base 設定（system font stack /
+         prefers-reduced-motion / :focus-visible 等）を CDN で動く形に整えて貼る。
+         @import 行は除き、@theme で定義された var(--color-*) はそのまま使える。 */
+    </style>
+  </head>
+
+  <body class="min-h-dvh bg-surface-base text-text-secondary">
+    <!-- メタ帯（ハーネス）。feature 名 / version / 関連リンク -->
+    <header class="border-b border-surface-border px-6 py-4">
+      <p class="text-caption text-text-tertiary">world-history-map · design mock</p>
+      <h1 class="mt-1 text-panel-title text-text-primary">{{FEATURE_NAME}} — {{VERSION}}</h1>
+      <!-- {{META_LINKS}} 関連 spec / issue / 前バージョンへのリンク（あれば。無ければ削除） -->
+    </header>
+
+    <!-- 状態スイッチャ（ハーネス）。async パネルのモック時のみ使い、不要なら丸ごと削除する。
+         data-state-tab の値と一致する [data-state] だけを表示する。 -->
+    <nav data-state-switcher class="flex gap-1 border-b border-surface-border px-6 py-2">
+      <button data-state-tab="loaded" class="rounded-lg px-3 py-1 text-body-sm">loaded</button>
+      <button data-state-tab="loading" class="rounded-lg px-3 py-1 text-body-sm">loading</button>
+      <button data-state-tab="empty" class="rounded-lg px-3 py-1 text-body-sm">empty</button>
+      <button data-state-tab="error" class="rounded-lg px-3 py-1 text-body-sm">error</button>
+    </nav>
+
+    <!-- ビューポート 2 枠（ハーネス）。desktop と mobile(375px) を並置 -->
+    <main class="flex flex-wrap items-start gap-8 p-6">
+      <!-- Desktop -->
+      <section>
+        <p class="mb-2 text-caption text-text-tertiary">Desktop</p>
+        <div
+          class="relative h-[760px] w-[1180px] max-w-full overflow-hidden rounded-lg border border-surface-border bg-surface-base"
+        >
+          <!-- マップ背景プレースホルダ（本番は MapLibre グローブ）。frosted glass を正しく見せる土台。
+               必要なら faint な静的ワールドマップ画像をここに敷く。 -->
+          <div class="absolute inset-0 bg-surface-base"></div>
+
+          <!-- {{DESKTOP_MOCK}} 実 UI をここに差し込む。DESIGN.md に則りトークン utility のみで組む。 -->
+        </div>
+      </section>
+
+      <!-- Mobile (375px) -->
+      <section>
+        <p class="mb-2 text-caption text-text-tertiary">Mobile · 375px</p>
+        <div
+          class="relative h-[760px] w-[375px] overflow-hidden rounded-lg border border-surface-border bg-surface-base"
+        >
+          <div class="absolute inset-0 bg-surface-base"></div>
+
+          <!-- {{MOBILE_MOCK}} モバイルは re-home（FAB + bottom sheet）として組む。 -->
+        </div>
+      </section>
+    </main>
+
+    <script>
+      // 状態スイッチャ（ハーネス JS）。data-state-tab を押すと一致する [data-state] のみ表示。
+      (function initStateSwitcher() {
+        const switcher = document.querySelector('[data-state-switcher]');
+        if (!switcher) return;
+
+        const tabs = Array.from(switcher.querySelectorAll('[data-state-tab]'));
+        const activeTabClasses = ['bg-surface-raised', 'text-text-primary'];
+        const idleTabClasses = ['text-text-tertiary'];
+
+        function applyState(state) {
+          for (const tab of tabs) {
+            const isActive = tab.dataset.stateTab === state;
+            tab.classList.toggle(activeTabClasses[0], isActive);
+            tab.classList.toggle(activeTabClasses[1], isActive);
+            tab.classList.toggle(idleTabClasses[0], !isActive);
+          }
+          for (const node of document.querySelectorAll('[data-state]')) {
+            node.hidden = node.dataset.state !== state;
+          }
+        }
+
+        for (const tab of tabs) {
+          tab.addEventListener('click', () => applyState(tab.dataset.stateTab));
+        }
+        applyState(tabs[0]?.dataset.stateTab ?? 'loaded');
+      })();
+    </script>
+  </body>
+</html>

--- a/biome.json
+++ b/biome.json
@@ -17,6 +17,7 @@
       "!apps/frontend/src/index.css",
       "!packages/design-tokens/src/theme.css",
       "!.claude/worktrees",
+      "!.claude/skills/**/*.html",
       "!design-mocks"
     ]
   },


### PR DESCRIPTION
## 概要

実装前に UI をモックで確認・比較検討するための skill `design-mock` を追加します。`design-mocks/<feature>/v<n>/index.html` に DESIGN.md 準拠の単一 HTML モックを生成します。

## 仕組み

- **トークン**: `packages/design-tokens/src/theme.css` の `@theme` を Tailwind v4 ブラウザ CDN の `<style type="text/tailwindcss">` に注入し、本番と同じトークン utility（`bg-surface-panel` `text-panel-title` …）でモックを組む
- **ルール・意図**: `DESIGN.md` に従い、`## Do's and Don'ts` でセルフレビューする
- **具体レシピ**: 実コンポーネントに合わせる
- `references/mock-shell.html` はモック雛形（CDN 配線・theme/base CSS 注入マーカー・desktop/mobile フレーム・状態スイッチャ）

## 動作確認

`theme.css` を Tailwind v4 ブラウザ CDN の `@theme` に注入すると、色だけでなくタイポグラフィロール（`text-panel-title` `text-year-hero` 等）まで本番同様に生成・描画されることを確認済み。

## ファイル

- `.claude/skills/design-mock/SKILL.md`
- `.claude/skills/design-mock/references/mock-shell.html`

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
