### PR TITLE
chore(nix): add flake dev shell providing tippecanoe and Node 24

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+use flake

--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@ build
 *.local
 .env*
 !.env.example
+!.envrc
 
 # Editor directories and files
 .vscode/*
@@ -49,6 +50,10 @@ storybook-static
 
 # Cloudflare
 .wrangler
+
+# Nix / direnv
+.direnv/
+/result
 
 # Playwright CLI
 .playwright-cli/

--- a/README.md
+++ b/README.md
@@ -1,0 +1,84 @@
+# world-history-map
+
+## Development
+
+See [`docs/overview.md`](./docs/overview.md) for architecture and [`CLAUDE.md`](./CLAUDE.md) for detailed guidelines.
+
+### Repository layout
+
+```text
+apps/
+  frontend/   # React app (MapLibre GL JS + react-map-gl + PMTiles)
+  pipeline/   # CLI data pipeline (Node.js, @turf/turf, tippecanoe)
+  worker/     # Cloudflare Worker (R2 tile serving)
+packages/
+  tiles/          # Hashed PMTiles build + manifest generation
+  design-tokens/  # Design token build (theme.css / MapLibre role colors)
+```
+
+pnpm workspaces, Node.js 24. pnpm is pinned via the `packageManager` field and resolved through corepack.
+
+### Development environment (Nix)
+
+System tools — notably `tippecanoe` / `tile-join` used by the data pipeline — and Node.js are provided by a Nix flake dev shell, so they don't need to be installed globally (e.g. via Homebrew).
+
+Prerequisites:
+
+- Nix with flakes enabled (`experimental-features = nix-command flakes`)
+- direnv + nix-direnv (recommended, for automatic activation)
+
+With direnv, allow the directory once and the shell is entered automatically on `cd`:
+
+```bash
+direnv allow
+```
+
+Without direnv:
+
+```bash
+nix develop
+```
+
+The shell provides `tippecanoe`, `tile-join`, and Node.js 24. Inside it, `pnpm` resolves to the version declared in `package.json` (`packageManager`) via corepack.
+
+> `op` (1Password CLI) is used by `pnpm territory-sync` to read Notion credentials and is intentionally **not** bundled in the flake — it relies on the 1Password desktop app integration. Install it on your system if you sync territory descriptions.
+
+### Common commands
+
+#### Frontend
+
+```bash
+pnpm dev          # Vite dev server (builds tiles first via predev)
+pnpm build        # Type-check and build
+pnpm storybook    # Storybook on port 6006
+```
+
+#### Quality gates
+
+```bash
+pnpm test && pnpm check && pnpm typecheck
+pnpm verify       # typecheck + biome check (no tests)
+pnpm format       # biome format --write .
+```
+
+#### Pipeline (data)
+
+```bash
+pnpm pipeline run --year 1600          # Process a single year
+pnpm pipeline run --years 1600..1800   # Process a year range
+pnpm territory-sync                    # Sync territory descriptions from Notion
+```
+
+#### Worker
+
+```bash
+pnpm --filter @world-history-map/worker run dev      # wrangler dev
+pnpm --filter @world-history-map/worker run deploy   # wrangler deploy
+```
+
+#### Tiles
+
+```bash
+pnpm --filter @world-history-map/tiles run build         # Hash PMTiles → dist/ + manifest.ts
+pnpm --filter @world-history-map/tiles run build:check   # CI gate: verify manifest is current
+```

--- a/biome.json
+++ b/biome.json
@@ -19,7 +19,8 @@
       "!packages/design-tokens/src/theme.css",
       "!.claude/worktrees",
       "!.claude/skills/**/*.html",
-      "!design-mocks"
+      "!design-mocks",
+      "!flake.lock"
     ]
   },
   "formatter": {

--- a/docs/pipeline.md
+++ b/docs/pipeline.md
@@ -138,9 +138,9 @@ git push
 
 外部ツール（PATH 上に必要）:
 
+- `tippecanoe` / `tile-join` — GeoJSON → MVT → PMTiles 変換とレイヤ結合。リポジトリ直下の Nix devShell (`flake.nix`) が提供する。`direnv allow` で自動有効化、または `nix develop` で入る
 - `git` — `historical-basemaps` の clone/pull
-- `tippecanoe` — GeoJSON → MVT → PMTiles
-- `op` — Notion 認証情報を 1Password から取り出す
+- `op` — Notion 認証情報を 1Password から取り出す（territory-sync 用）。Nix devShell には含めないためシステムに別途インストールする
 
 出力先:
 

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1779796641,
+        "narHash": "sha256-ZsIrKmhp4vbBXoXXmR/tBXA/UCsAQiJL9vsgZEduhVY=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "25f538306313eae3927264466c70d7001dcea1df",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-25.11",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,27 @@
+{
+  description = "Development environment for world-history-map";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-25.11";
+  };
+
+  outputs = { nixpkgs, ... }:
+    let
+      systems = [ "aarch64-darwin" "x86_64-darwin" "aarch64-linux" "x86_64-linux" ];
+      forAllSystems = nixpkgs.lib.genAttrs systems;
+    in
+    {
+      devShells = forAllSystems (system:
+        let
+          pkgs = nixpkgs.legacyPackages.${system};
+        in
+        {
+          default = pkgs.mkShell {
+            packages = with pkgs; [
+              nodejs_24
+              tippecanoe
+            ];
+          };
+        });
+    };
+}


### PR DESCRIPTION
## 概要

tippecanoe をはじめとするパイプラインのシステムツールと Node.js 24 を、リポジトリに閉じた Nix flake の devShell から提供するようにしました。Homebrew などでグローバルに入れる必要がなくなり、環境が変わっても同じバージョンで動くようになります。

### 背景

- パイプラインの PMTiles 変換は `tippecanoe` / `tile-join` というシステムバイナリに依存していますが、これまでは各自がグローバルに用意する前提で、`docs/pipeline.md` に「PATH 上に必要」と書かれているだけで導入手順がありませんでした。
- このリポジトリでしか使わないツールをグローバル環境に入れたくない、かつ複数マシン間で同じバージョンを再現したい、という動機があります。

### 設計判断

- **pnpm は flake に含めず corepack を継続**します。`packageManager` の pnpm 10.33.2 を devShell 内でも corepack がそのまま解決するためで、flake に入れると nixpkgs 版とのバージョン乖離・二重管理が生じます。
- **`op`（1Password CLI）は flake に含めません**。nix 版は macOS デスクトップアプリ連携（Touch ID）が効かず、territory-sync の `op read` 認証が壊れる恐れがあるため、システム導入のままにしています。
- **`.nvmrc` は残します**。Cloudflare Pages の本番フロントビルドは `NODE_VERSION` 未設定で `.nvmrc` を自動検出して Node バージョンを決めており（API で確認済み）、削除すると古い Node にフォールバックします。flake（ローカル devShell）とは消費者が異なり冗長ではありません。
- **`flake.lock` を biome の対象外**にしました。commit する JSON のため、除外しないと整形でドリフトし CI lint が落ちます。

### 影響範囲

- CI は変更していません。CI は tippecanoe を呼ばず（タイルは事前ビルド済みを commit）、`actions/setup-node` + `pnpm/action-setup` で完結しているためです。devShell はローカル開発専用です。
- `.gitignore` の `.env*` が `.envrc` を巻き込んでいたため `!.envrc` で除外解除しました。これがないと direnv 設定がコミットされません。
- 既存の開発フローへの破壊的変更はありません。direnv 未導入でも `nix develop` で同じ環境に入れます。

## 動作確認

### 自動確認済み

- [x] `pnpm check`（biome）— 262 ファイル問題なし。`flake.lock` 除外・`.nix` / `.envrc` も無害
- [x] `pnpm typecheck` — 通過
- [x] devShell 内のバイナリ確認: `tippecanoe` 2.79.0 / `tile-join` 同梱 / `node` v24.16.0 / `pnpm` 10.33.2（corepack 経由）

### 手動確認

- [ ] `direnv allow` 後、`cd` で自動的に devShell へ入ること
- [ ] `pnpm pipeline run`（単年）で tippecanoe が実際に呼ばれ PMTiles が生成されること（本 PR では git 管理のタイル成果物を再生成しないため未実施）

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
