### PR TITLE
chore(nix): provide apm via pinned uvx wrapper

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,3 +61,4 @@ storybook-static
 
 # APM dependencies
 apm_modules/
+.agents/

--- a/flake.nix
+++ b/flake.nix
@@ -11,6 +11,8 @@
       forAllSystems = nixpkgs.lib.genAttrs systems;
       # Lag spec-kit one week behind upstream as a cooldown; bump only to tags released >= 7 days ago.
       speckitVersion = "v0.8.17";
+      # Lag apm one week behind upstream as a cooldown; bump only to tags released >= 7 days ago.
+      apmVersion = "v0.16.0";
     in
     {
       devShells = forAllSystems (system:
@@ -21,6 +23,11 @@
               --from "git+https://github.com/github/spec-kit.git@${speckitVersion}" \
               specify "$@"
           '';
+          apm = pkgs.writeShellScriptBin "apm" ''
+            exec ${pkgs.uv}/bin/uv tool run \
+              --from "git+https://github.com/microsoft/apm.git@${apmVersion}" \
+              apm "$@"
+          '';
         in
         {
           default = pkgs.mkShell {
@@ -30,7 +37,7 @@
               pnpm_11
               tippecanoe
               uv
-            ]) ++ [ specify ];
+            ]) ++ [ specify apm ];
           };
         });
     };


### PR DESCRIPTION
## 概要

apm（Agent Package Manager）を Nix の dev shell から再現性高く利用できるようにします。これまで手動インストールに依存していたメンテナ向けツールを、flake で固定管理された `apm` コマンドに置き換えます。

### 背景

- apm はこれまで `/usr/local` に self-update する prebuilt バイナリとして手動インストールされており、flake 管理外でした。
- スキル成果物（`.claude/skills/`）は commit 済みのため利用者側の再現性は満たされていましたが、`apm.yml` を編集してスキルを再同期するメンテナ作業の再現性と、自動更新バイナリの供給網リスクが残っていました。

### 設計判断

- **既存の spec-kit と同じ uvx ラッパー方式**を採用しました。nixpkgs の `apm-cli` は stable（25.11 / 26.05）に無く unstable 専用かつ上流より遅れているため、第 2 の input を抱えるより、既存の `uv` を再利用する方が軽量で一貫します。

  | 方式 | 評価 |
  |---|---|
  | uvx ラッパー（採用） | ✅ 追加 input 不要・バージョン自由・spec-kit と同方式 |
  | nixpkgs `apm-cli` | ❌ stable に無く unstable 専用、closure が重い |

- **バージョンはリリースから 7 日以上経過した最新タグ（v0.16.0）に固定**しました。spec-kit / pnpm と同じサプライチェーン・クールダウン方針に揃えています。
- `.agents/` を `.gitignore` に追加しました。apm 0.16.0 が `.claude/skills/` に加えて生成する成果物で、内容は同一（content hash 一致）のため追跡対象から外します。

### 影響範囲

- 変更は dev shell（`flake.nix`）と `.gitignore` のみで、アプリのコード・ビルドには影響しません。`flake.lock` も不変です（新規 input なし）。
- 再現性はハイブリッドです。flake が固定するのは uv・ラッパー・apm の git タグまでで、依存解決と Python は実行時に uv が処理します（初回のみネットワーク取得）。
- 既存の `/usr/local` の手動 apm の撤去は、root 権限が必要なため本 PR の範囲外です（ローカルで別途実施します）。

## 動作確認

### 自動確認済み

- [x] `nix build .#devShells.<system>.default`（flake 評価・devShell ビルド）
- [x] `nix develop --command apm --version` → `0.16.0`
- [x] `nix develop --command apm install`（`apm.yml` の依存を再同期し、スキルの content hash が既存と一致）

### 手動確認

- [ ] `/usr/local` の旧 apm 撤去後、dev shell 内で `apm` が nix 版を指すこと

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
